### PR TITLE
create same url as for save map if application is not geoexplorer

### DIFF
--- a/geoexplorer/app/static/script/app/GeoExplorer/Composer.js
+++ b/geoexplorer/app/static/script/app/GeoExplorer/Composer.js
@@ -644,9 +644,9 @@ GeoExplorer.Composer = Ext.extend(GeoExplorer, {
        
        /* If application is not geoexplorer - but another application using
        * geoexplorer - dont assume /viewer file to be the presentation file */
-       var publishUrl = "../viewer/#maps/" + this.id
+       var publishUrl = "../viewer/#maps/" + this.id;
        if (window.location.href.indexOf('geoexplorer') == -1) {
-           publishUrl = window.location.href
+           publishUrl = window.location.href;
        }
        var embedMap = new gxp.EmbedMapDialog({
            id: 'geobuilder-1',

--- a/geoexplorer/app/static/script/app/GeoExplorer/Composer.js
+++ b/geoexplorer/app/static/script/app/GeoExplorer/Composer.js
@@ -641,10 +641,16 @@ GeoExplorer.Composer = Ext.extend(GeoExplorer, {
                this.save();
            }
        };
-
+       
+       /* If application is not geoexplorer - but another application using
+       * geoexplorer - dont assume /viewer file to be the presentation file */
+       var publishUrl = "../viewer/#maps/" + this.id
+       if (window.location.href.indexOf('geoexplorer') == -1) {
+           publishUrl = window.location.href
+       }
        var embedMap = new gxp.EmbedMapDialog({
            id: 'geobuilder-1',
-           url: "../viewer/#maps/" + this.id
+           url: publishUrl
        });
 
        var wizard = {


### PR DESCRIPTION
Make it possible to use another view than viewer when creating url for publish map. Do this in the same way as is done for save map.