### PR TITLE
move toolbar to northpanel instead of tbar of portalItems

### DIFF
--- a/geoexplorer/app/static/script/app/GeoExplorer/Composer.js
+++ b/geoexplorer/app/static/script/app/GeoExplorer/Composer.js
@@ -535,14 +535,24 @@ GeoExplorer.Composer = Ext.extend(GeoExplorer, {
             activeItem: 0
         });
         
+        var northPanel = new Ext.Panel({
+            border: true,
+            region: "north",
+            split: true,
+            height: 30,
+            bbar: toolbar,
+            id: "panelHeading",
+            collapseMode: "mini"            
+        });          
+        
         this.portalItems = [{
             region: "center",
             layout: "border",
-            tbar: toolbar,
             items: [
                 this.mapPanelContainer,
                 westPanel,
-                southPanel
+                southPanel,
+                northPanel
             ]
         }];
         


### PR DESCRIPTION
This makes it easier to create headings to geoexplorer. Without it, the toolbar moves to the top of the page. With this change it stays above the map panel, but at the bottom of the north panel.
