### PR TITLE
PUT style thows an exception if it fails to save the file

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/LayerController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/LayerController.java
@@ -527,7 +527,15 @@ public class LayerController extends ApiController {
             }
         }
         finally {
-            IOUtils.closeQuietly(output);
+            try {
+                //For a FileSystemResource, a temp file is copied to the actual file on close().
+                output.close();
+            } catch (NullPointerException npe) {
+                //The temp file has already been saved and deleted, therefore npe (not an error).
+            } catch (IOException ioe) {
+                //Failed to modify one of the files. We have probably failed to save the changes.
+                throw new RuntimeException("Failed to modify resource",ioe);
+            }
         }
 
         if (s.getId() == null) {


### PR DESCRIPTION
Updates the implementation of the PUT style api handle to throw an error if it fails to save the file.

No test case because the  mock catalog framework has no way of accessing the underlying files (and therefore no way of locking the files).