### PR TITLE
Editor Copy/Paste

### DIFF
--- a/geoserver/webapp/app/components/styleditor/styleditor.js
+++ b/geoserver/webapp/app/components/styleditor/styleditor.js
@@ -14,9 +14,9 @@ angular.module('gsApp.styleditor', [
   'gsApp.styleditor.display'
 ])
 .directive('styleEditor', ['$compile', '$sanitize', '$timeout', '$log',
-    'YsldHinter', '$rootScope',
+    'YsldHinter', '$rootScope', '$document',
     function($compile, $sanitize, $timeout, $log, YsldHinter,
-      $rootScope) {
+      $rootScope, $document) {
       return {
         restrict: 'EA',
         scope: {
@@ -103,15 +103,28 @@ angular.module('gsApp.styleditor', [
             tabMode: 'spaces'
           };
 
+          $scope.setPopup = function(){
+            //Wait a little bit before setting the popover element. We need to
+            //ensure that it exists so we can remove it later on if necessary.
+            //If we don't explicitly remove it then the popover will remain on
+            //the new code mirror window.
+            $timeout(function() {
+              $rootScope.popoverElement = angular.element(
+                $document[0].querySelectorAll('.popover'));
+            }, 250);
+          };
+
           $scope.$watch('markers', function(newVal) {
             $scope.editor.clearGutter('markers');
             if (newVal != null) {
               newVal.forEach(function(mark) {
-                var html = '<i class="icon-warning" ' +
+                var html = '<a class="icon-warning" ' +
                   'popover="' + $sanitize(mark.problem) + '" ' +
                   'popover-placement="left" ' +
-                  'popover-trigger="mouseenter" ' +
-                  'popover-append-to-body="true"></i>';
+                  'popover-append-to-body="true"' +
+                  'title="Click to toggle the error message on/off." ' +
+                  'alt="Click to toggle the error message on/off."' +
+                  'ng-click="setPopup()"></a>';
 
                 var marker = $compile(html)($scope)[0];
                 $scope.editor.setGutterMarker(mark.line, 'markers', marker);

--- a/geoserver/webapp/app/maps/detail/editorsave-modal.tpl.html
+++ b/geoserver/webapp/app/maps/detail/editorsave-modal.tpl.html
@@ -10,7 +10,8 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button class="btn btn-success btn-sm" ng-click="saveChanges()">Save</button>
+    <button ng-show="linterIsvalid" class="btn btn-success btn-sm" ng-click="saveChanges()">Save</button>
     <button class="btn btn-danger btn-sm" ng-click="discardChanges()">Discard</button>
+    <button class="btn btn-default" ng-click="cancel()">Cancel</button
   </div>
 </div>


### PR DESCRIPTION
Adding the ability to select error information from the editor.
Extending the 'isDirty' functionality.

Use cases:
1. User enters a valid change (no syntax errors) and hits save: style is saved and the user is able to move on.
2. User enters a valid change (no syntax errors) and chooses a new URL or layer: operation is stopped, user is prompted to save, discard or cancel changes (functionality described below).
3. User enters an invalid change (syntax errors) and hits save: operation is stopped and gutter marker appears in editor. Clicking on the marker shows a descriptive error message that can be copied.
4. User enters an invalid change (syntax errors) and chooses a new URL or layer: operation is stopped, user is prompted to discard or cancel changes only (functionality described below).

Modal functionality:
Save: saves style, closes modal window, removes the modal backdrop and moves to new workspace or layer, whichever the user selected prior to the modal window appearing.

Discard: editor rolls back to last saved state, resets all markers, closes any open popup windows and moves to new workspace or layers, which the user selected prior to the modal window appearing.

Cancel: closes the modal window and removes the modal backdrop.