### PR TITLE
Api import

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
@@ -411,13 +411,13 @@ public class ImportController extends ApiController {
     }
 
     JSONObj ignored(ImportTask task) {
-        return new JSONObj().put("task", task.getId()).put("file", filename(task));
+        return new JSONObj().put("task", task.getId()).put("name", name(task));
     }
     
-    String filename(ImportTask task) {
+    /*String filename(ImportTask task) {
         ImportData data = task.getData();
         return FilenameUtils.getName(data.toString());
-    }
+    }*/
     
     String name(ImportTask task) {
         ImportData data = task.getData();

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -1,4 +1,4 @@
-/* (c) 2014 Boundless, http://boundlessgeo.com
+/* (c) 2014-2014 Boundless, http://boundlessgeo.com
  * This code is licensed under the GPL 2.0 license.
  */
 package com.boundlessgeo.geoserver;
@@ -9,8 +9,10 @@ import com.boundlessgeo.geoserver.api.controllers.WorkspaceController;
 import com.boundlessgeo.geoserver.json.JSONArr;
 import com.boundlessgeo.geoserver.json.JSONObj;
 import com.boundlessgeo.geoserver.util.RecentObjectCache;
+
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+
 import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.CatalogBuilder;
@@ -18,10 +20,12 @@ import org.geoserver.catalog.LayerGroupInfo;
 import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.StyleInfo;
 import org.geoserver.data.test.SystemTestData;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.importer.Importer;
+import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
-import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.data.DataStore;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.MediaType;
@@ -32,11 +36,21 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import javax.mail.internet.InternetHeaders;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMultipart;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,7 +58,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
-public class AppIntegrationTest extends GeoServerSystemTestSupport {
+public class AppIntegrationTest extends DbTestSupport {
 
     @Override
     protected void setUpTestData(SystemTestData testData) throws Exception {
@@ -147,6 +161,63 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         StyleInfo s = l.getDefaultStyle();
         assertNotNull(s.getWorkspace());
     }
+    
+    @Test
+    public void testImportDb() throws Exception {
+        buildTestData((SystemTestData) testData);
+        //DataStoreInfo ds = createH2DataStore(null, "h2");
+        //populateDatabase(ds);
+        if (!isTestDataAvailable()) {
+            LOGGER.warning("Skipping testImportDb because online test data is not available");
+            return;
+        }
+        
+        Catalog catalog = getCatalog();
+        assertNull(catalog.getLayerByName("gs:point"));
+
+        Importer importer =
+            GeoServerExtensions.bean(Importer.class, applicationContext);
+        ImportController ctrl = new ImportController(getGeoServer(), importer);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("/geoserver");
+        request.setRequestURI("/geoserver/hello");
+        request.setMethod("post");
+        
+        JSONObj obj = dbTestData.createConnectionParameters();
+        obj = ctrl.importDb("gs", obj);
+        
+        Long id = Long.parseLong(obj.get("id").toString());
+        assertNotNull(id);
+        JSONArr preimport = obj.array("preimport");
+        assertTrue(3 <= preimport.size());
+        assertEquals(0, obj.array("imported").size());
+        assertEquals(0, obj.array("pending").size());
+        assertEquals(0, obj.array("failed").size());
+        assertEquals(0, obj.array("ignored").size());
+        
+        List<String> names = Arrays.asList(new String[]{"ft1","ft2","ft3"});
+        JSONArr tasks = new JSONArr();
+        for (JSONObj o : preimport.objects()) {
+            if (names.contains(o.get("name"))) {
+                tasks.add(o.get("task").toString());
+                assertEquals("table", o.get("type"));
+            }
+        }
+        assertEquals(3, tasks.size());
+        JSONObj response = new JSONObj();
+        response.put("tasks", tasks);
+        
+        obj = ctrl.update("gs", id, response);
+        
+        assertEquals(0, obj.array("preimport").size());
+        assertEquals(1, obj.array("imported").size());
+        assertEquals(2, obj.array("pending").size());
+        assertEquals(0, obj.array("failed").size());
+        assertEquals(preimport.size()-3, obj.array("ignored").size());
+        
+        obj = ctrl.get("gs",  id);
+    }
 
     @Test
     public void testIconsUploadDelete() throws Exception {
@@ -204,6 +275,59 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         assertNotNull(cat.getLayerByName("gs:PrimitiveGeoFeature"));
     }
 
+    public JSONObj createConnectionParameters(Map connectionParameters) throws IOException {
+        JSONObj obj = new JSONObj();
+        for (Object key : connectionParameters.keySet()) {
+            obj.put(key.toString(), connectionParameters.get(key).toString());
+        }
+        
+        return obj;
+    }
+    protected DataStoreInfo createH2DataStore(String wsName, String dsName) {
+        //create a datastore to import into
+        Catalog cat = getCatalog();
+
+        WorkspaceInfo ws = wsName != null ? cat.getWorkspaceByName(wsName) : cat.getDefaultWorkspace();
+        DataStoreInfo ds = cat.getFactory().createDataStore();
+        ds.setWorkspace(ws);
+        ds.setName(dsName);
+        ds.setType("H2");
+
+        Map params = new HashMap();
+        params.put("database", getTestData().getDataDirectoryRoot().getPath()+"/" + dsName);
+        params.put("dbtype", "h2");
+        ds.getConnectionParameters().putAll(params);
+        ds.setEnabled(true);
+        cat.add(ds);
+        
+        return ds;
+    }
+    protected Connection getConnection(DataStoreInfo ds) throws Exception {
+        Map p = ds.getConnectionParameters();
+        Class.forName((String)p.get("driver"));
+        
+        String url = (String) p.get("url");
+        String user = (String) p.get("username");
+        String passwd = (String) p.get("password");
+        
+        return DriverManager.getConnection(url, user, passwd);
+    }
+    protected void populateDatabase(DataStoreInfo ds) throws Exception {
+        Connection conn = getConnection(ds);
+
+        if (conn == null) {
+            return;
+        }
+
+        // read the script and run the setup commands
+        Statement st = conn.createStatement();
+        runSafe("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = 'ft1'", st);
+
+        runSafe("DROP TABLE \"ft1\"", st);
+        runSafe("DROP TABLE \"ft2\"", st);
+        runSafe("DROP TABLE \"ft3\"", st);
+    }
+    
     MockHttpServletResponse doWorkspaceExport(String wsName) throws Exception {
         WorkspaceController ctrl = new WorkspaceController(getGeoServer(), new RecentObjectCache());
 

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -200,7 +200,7 @@ public class AppIntegrationTest extends DbTestSupport {
         JSONArr tasks = new JSONArr();
         for (JSONObj o : preimport.objects()) {
             if (names.contains(o.get("name"))) {
-                tasks.add(o.get("task").toString());
+                tasks.add(new JSONObj().put("task", o.get("task").toString()));
                 assertEquals("table", o.get("type"));
             }
         }

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/DbTestSupport.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/DbTestSupport.java
@@ -1,0 +1,185 @@
+/* (c) 2014-2014 Boundless, http://boundlessgeo.com
+ * This code is licensed under the GPL 2.0 license.
+ */
+package com.boundlessgeo.geoserver;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.logging.Level;
+
+import org.geoserver.data.test.LiveDbmsData;
+import org.geoserver.data.test.SystemTestData;
+import org.geoserver.test.GeoServerSystemTestSupport;
+import com.boundlessgeo.geoserver.json.JSONObj;
+
+public class DbTestSupport extends GeoServerSystemTestSupport {
+    
+    DbmsTestData dbTestData;
+    
+    @Override
+    public void onSetUp(SystemTestData testData) throws Exception {
+        dbTestData = new DbmsTestData(testData.getDataDirectoryRoot(), getFixtureId(), createSql());
+        dbTestData.setUp();
+    }
+    
+    protected void buildTestData(SystemTestData testData) throws Exception {
+        dbTestData = new DbmsTestData(testData.getDataDirectoryRoot(), getFixtureId(), createSql());
+        dbTestData.setUp();
+    }
+    
+    @Override
+    public void onTearDown(SystemTestData testData) throws Exception {
+        if (dbTestData == null) {
+            dbTestData = new DbmsTestData(testData.getDataDirectoryRoot(), getFixtureId(), null);
+        }
+        if (!isTestDataAvailable()) {
+            return;
+        }
+        Connection conn = dbTestData.getConnection();
+
+        if (conn == null) {
+            return;
+        }
+
+        // read the script and run the setup commands
+        Statement st = conn.createStatement();
+        runSafe("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = 'ft1'", st);
+
+        runSafe("DROP TABLE \"ft1\"", st);
+        runSafe("DROP TABLE \"ft2\"", st);
+        runSafe("DROP TABLE \"ft3\"", st);
+    }
+    
+    private File createSql() throws IOException {
+        //drop old data
+        File sql =  File.createTempFile("DbTestSupport", ".sql");
+        
+        final String nl = ";"+ System.getProperty("line.separator");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(sql));
+        
+        writer.write("DELETE FROM GEOMETRY_COLUMNS WHERE F_TABLE_NAME = 'ft1'"+nl);
+        writer.write("DROP TABLE \"ft1\""+nl);
+        writer.write("DROP TABLE \"ft2\""+nl);
+        writer.write("DROP TABLE \"ft3\""+nl);
+        
+        writer.write("CREATE TABLE \"ft1\"(" //
+                + "\"id\" serial primary key, " //
+                + "\"geometry\" geometry, " //
+                + "\"stringProperty\" varchar)"+nl);
+        writer.write("INSERT INTO GEOMETRY_COLUMNS VALUES('', 'public', 'ft1', 'geometry', 2, '4326', 'POINT')"+nl);
+        
+        writer.write("INSERT INTO \"ft1\" VALUES(0, ST_GeometryFromText('POINT(0 0)', 4326), 'zero')"+nl); 
+        writer.write("INSERT INTO \"ft1\" VALUES(1, ST_GeometryFromText('POINT(1 1)', 4326), 'one')"+nl);
+        writer.write("INSERT INTO \"ft1\" VALUES(2, ST_GeometryFromText('POINT(2 2)', 4326), 'two')"+nl);
+        
+        
+        // ft2: like ft1 but no srid registered
+        writer.write("CREATE TABLE \"ft2\"(" //
+                + "\"id\" serial primary key, " //
+                + "\"geometry\" geometry, " //
+                + "\"stringProperty\" varchar)"+nl);
+        writer.write("INSERT INTO \"ft2\" VALUES(0, ST_GeometryFromText('POINT(0 0)'), 'one')"+nl);
+        
+        // ft3: like ft1 but no geometry column
+        writer.write("CREATE TABLE \"ft3\"(" //
+                + "\"id\" serial primary key, " //
+                + "\"stringProperty\" varchar)"+nl);
+        writer.write("INSERT INTO \"ft3\" VALUES(0, 'zero')"+nl);
+        writer.close();
+        
+        return sql;
+    }
+    
+    public boolean isTestDataAvailable() {
+        if (dbTestData == null) {
+            return false;
+        }
+        if (dbTestData.isTestDataAvailable()) {
+            //actually try a connection
+            try {
+                dbTestData.getConnection();
+                return true;
+            }
+            catch(Exception e) {
+                LOGGER.log(Level.SEVERE, "Could not obtain connection", e);
+            }
+        }
+        return false;
+    }
+
+    
+
+    
+    
+    protected String getFixtureId() {
+        return "postgis";
+    }
+
+  
+
+    protected void run(String sql, Statement st) throws SQLException {
+        st.execute(sql);
+    }
+
+    protected void runSafe(String sql, Statement st) {
+        try {
+            run(sql, st);
+        }
+        catch(SQLException e) {
+            LOGGER.log(Level.FINE, e.getLocalizedMessage(), e);
+        }
+    }
+
+    class DbmsTestData extends LiveDbmsData {
+
+        public DbmsTestData(File dataDirSourceDirectory, String fixtureId, File sqlScript)
+            throws IOException {
+            super(dataDirSourceDirectory, fixtureId, sqlScript);
+            getFilteredPaths().clear();
+        }
+        
+        public Map getConnectionParams() throws IOException {
+            Properties props = new Properties();
+            FileInputStream fin = new FileInputStream(fixture);
+            try {
+                props.load(fin);
+            }
+            finally {
+                fin.close();
+            }
+            
+            return new HashMap(props);
+        }
+        
+        public JSONObj createConnectionParameters() throws IOException {
+            JSONObj obj = new JSONObj();
+            Map fixture = getConnectionParams();
+            for (Object key : fixture.keySet()) {
+                obj.put(key.toString(), fixture.get(key).toString());
+            }
+            
+            return obj;
+        }
+        
+        public Connection getConnection() throws Exception {
+            Map p = getConnectionParams();
+            Class.forName((String)p.get("driver"));
+            
+            String url = (String) p.get("url");
+            String user = (String) p.get("username");
+            String passwd = (String) p.get("password");
+            
+            return DriverManager.getConnection(url, user, passwd);
+        }
+    }
+}


### PR DESCRIPTION
@eshon Here are the fixes we discussed. Note that the import api PUT now only acceps lists of **objects** or filters:

    { 
        "tasks":[
            {
                 "task": 0
            },
            {
                 "task": 1,
                 "proj": "epsg:3857"
            }]
    }

Or:

    { "filter":"ALL" }

This was neccessary to support the two possible response types. `proj` is only required if you are updating the projection.
Feel free to merge these changes when you are ready to update the front-end to support this change.
Note that the new test cases are a bit finicky, so disregard failures of "testImportDb" for now (It will only actually run if you have a postgis db set up).

