### PR TITLE
Import API returns session timeout

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/LoginController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/LoginController.java
@@ -30,6 +30,7 @@ public class LoginController {
         HttpSession session = req.getSession(false);
         if (session != null) {
             obj.put("session", session.getId());
+            obj.put("timeout", session.getMaxInactiveInterval());
         }
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();


### PR DESCRIPTION
@eshon Session timeout is now returned from Composer login api. Value in **seconds**. Example:

    {
        "session":"11u4o123io5rg6p79386zxqm3"
        "timeout":1800
        "user":"admin"
    }