### PR TITLE
Postgis import

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
@@ -9,7 +9,6 @@ import com.boundlessgeo.geoserver.json.JSONArr;
 import com.boundlessgeo.geoserver.json.JSONObj;
 import com.boundlessgeo.geoserver.util.Hasher;
 import com.google.common.collect.Maps;
-
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -409,7 +408,7 @@ public class ImportController extends ApiController {
         }
         return imp;
     }
-
+    
     void touch(ImportTask task) {
         LayerInfo l = task.getLayer();
         l = catalog().getLayer(l.getId());
@@ -425,7 +424,8 @@ public class ImportController extends ApiController {
         JSONObj obj = new JSONObj();
         obj.put("task", task.getId())
            .put("name", name(task))
-           .put("type", type(task));
+           .put("type", type(task))
+           .put("geometry", IO.geometry(task.getLayer()));
         return obj;
     }
 

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
@@ -9,13 +9,19 @@ import com.boundlessgeo.geoserver.json.JSONArr;
 import com.boundlessgeo.geoserver.json.JSONObj;
 import com.boundlessgeo.geoserver.util.Hasher;
 import com.google.common.collect.Maps;
+
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CoverageStoreInfo;
+import org.geoserver.catalog.DataStoreInfo;
 import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.NamespaceInfo;
 import org.geoserver.catalog.ResourceInfo;
+import org.geoserver.catalog.StoreInfo;
 import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WMSStoreInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerDataDirectory;
@@ -89,22 +95,40 @@ public class ImportController extends ApiController {
         // pass off the uploaded file to the importer
         Directory dir = new Directory(uploadDir);
         dir.accept(files.next());
+        
+        ImportContext imp = importer.createContext(dir, ws);
+        
+        //Check if this store already exists in the catalog
+        StoreInfo store = findStore(imp, ws);
+        if (store != null) {
+            return store(new JSONObj(), store, request);
+        }
 
-        return doImport(dir, ws);
+        return doImport(imp, ws);
     }
 
     @RequestMapping(value = "/{wsName}", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody JSONObj importDb(@PathVariable String wsName, @RequestBody JSONObj obj) throws Exception {
+    public @ResponseBody JSONObj importDb(@PathVariable String wsName, @RequestBody JSONObj obj, 
+            HttpServletRequest request) throws Exception {
+        
         // grab the workspace
         Catalog catalog = geoServer.getCatalog();
         WorkspaceInfo ws = findWorkspace(wsName, catalog);
-
+        
         // create the import data
         Database db = new Database(hack(obj));
         
-        //Initialize the import, and return to requester to allow selection of tables.
+        ImportContext imp = importer.createContext(db, ws);
+        
+        //Check if this store already exists in the catalog
+        StoreInfo store = findStore(imp, ws);
+        if (store != null) {
+            return store(new JSONObj(), store, request);
+        }
+        
+        //Return to requester to allow selection of tables.
         //Complete the import using update()
-        return prepImport(db, ws);
+        return get(ws.getName(), imp.getId());
     }
 
     Map<String, Serializable> hack(JSONObj obj) {
@@ -153,28 +177,21 @@ public class ImportController extends ApiController {
     }
     
     /*
-     * Set up an import context. 
-     * Use continueImport() to complete this import
-     * 
      * @param data - The data to import
      * @param ws - The workspace to import into
      * @return JSON representation of the import
      */
-    JSONObj prepImport(ImportData data, WorkspaceInfo ws) throws Exception {
-        // prepare the import and extract layers
-        ImportContext imp = importer.createContext(data, ws);
-        return get(ws.getName(), imp.getId());
+    JSONObj doImport(ImportContext imp, WorkspaceInfo ws) throws Exception {
+        return doImport(imp, ws, ImportFilter.ALL);
     }
     
     /*
-     * Complete an import started with prepImport().
-     * 
      * @param imp - The context to run the import from
      * @param ws - The workspace to import into
      * @param f - Filter to select import tasks
      * @return JSON representation of the import
      */
-    JSONObj continueImport(ImportContext imp, WorkspaceInfo ws, ImportFilter f) throws Exception {
+    JSONObj doImport(ImportContext imp, WorkspaceInfo ws, ImportFilter f) throws Exception {
         // run the import
         imp.setState(ImportContext.State.RUNNING);
         GeoServerDataDirectory dataDir = dataDir();
@@ -227,32 +244,7 @@ public class ImportController extends ApiController {
         imp.setState(ImportContext.State.COMPLETE);
         return get(ws.getName(), imp.getId());
     }
-
-    /*
-     * run an import in one step
-     * @param data - The data to import
-     * @param ws - The workspace to import into
-     * @return JSON representation of the import
-     */
-    JSONObj doImport(ImportData data, WorkspaceInfo ws) throws Exception {
-        // run the import
-        ImportContext imp = importer.createContext(data, ws);
-        imp.setState(ImportContext.State.RUNNING);
-        GeoServerDataDirectory dataDir = dataDir();
-        for (ImportTask t : imp.getTasks()) {
-            prepTask(t, ws, dataDir);
-        }
-        importer.run(imp);
-
-        for (ImportTask t : imp.getTasks()) {
-            if (t.getState() == ImportTask.State.COMPLETE) {
-                touch(t);
-            }
-        }
-        imp.setState(ImportContext.State.COMPLETE);
-        return get(ws.getName(), imp.getId());
-    }
-
+    
     void prepTask(ImportTask t, WorkspaceInfo ws, GeoServerDataDirectory dataDir) {
         // 1. hack the context object to ensure that all styles are workspace local
         // 2. mark layers as "imported" so we can safely delete styles later
@@ -355,7 +347,7 @@ public class ImportController extends ApiController {
         if (imp.getState() == ImportContext.State.PENDING) {
             // create the import data
             
-            return continueImport(imp, ws, f);
+            return doImport(imp, ws, f);
         }
         
         //Re-import
@@ -407,6 +399,48 @@ public class ImportController extends ApiController {
             throw new NotFoundException("No such import: " + id);
         }
         return imp;
+    }
+    
+    StoreInfo findStore(ImportContext imp, WorkspaceInfo ws) throws Exception {
+        Catalog catalog = geoServer.getCatalog();
+        ImportData data = imp.getData();
+        if (data.getFormat() == null) {
+            return null;
+        }
+        
+        StoreInfo store = data.getFormat().createStore(data, ws, catalog);
+        if (!store.getConnectionParameters().containsKey("namespace")) {
+            if (ws != null) {
+                NamespaceInfo ns = catalog.getNamespaceByPrefix(ws.getName());
+                if (ns != null) {
+                    store.getConnectionParameters().put("namespace", ns.getURI());
+                }
+            }
+        }
+        Class<? extends StoreInfo> clazz = StoreInfo.class;
+        if (store instanceof CoverageStoreInfo) {
+            clazz = CoverageStoreInfo.class;
+        } else if (store instanceof DataStoreInfo) {
+            clazz = DataStoreInfo.class;
+        } else if (store instanceof WMSStoreInfo) {
+            clazz = WMSStoreInfo.class;
+        }
+        List<? extends StoreInfo> stores = catalog.getStoresByWorkspace(ws, clazz);
+        for (StoreInfo s : stores) {
+            if (s.getConnectionParameters().equals(store.getConnectionParameters())) {
+                return s;
+            }
+        }
+        return null;
+    }
+    
+    JSONObj store(JSONObj obj, StoreInfo store, HttpServletRequest req) {
+        String wsName = store.getWorkspace().getName();
+        obj.put("store",store.getName())
+           .put("workspace",wsName)
+           .put("url", IO.url(req, "/stores/%s/%s",wsName, store.getName()));
+        
+        return obj;
     }
     
     void touch(ImportTask task) {

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -3,6 +3,7 @@
  */
 package com.boundlessgeo.geoserver;
 
+import com.boundlessgeo.geoserver.api.controllers.IO;
 import com.boundlessgeo.geoserver.api.controllers.IconController;
 import com.boundlessgeo.geoserver.api.controllers.ImportController;
 import com.boundlessgeo.geoserver.api.controllers.WorkspaceController;
@@ -24,6 +25,7 @@ import org.geoserver.importer.Importer;
 import org.geoserver.platform.GeoServerExtensions;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.test.GeoServerSystemTestSupport;
+import org.geotools.referencing.CRS;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.MediaType;
@@ -41,8 +43,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -150,60 +155,95 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         // ensure style in workspace
         StyleInfo s = l.getDefaultStyle();
         assertNotNull(s.getWorkspace());
+        
+        //Try to reimport the same store - should succeed
+        createMultiPartFormContent(request, "form-data; name=\"upload\"; filename=\"point.zip\"", "application/zip",
+                IOUtils.toByteArray(getClass().getResourceAsStream("point.shp.zip")));
+        obj = ctrl.importFile("gs", request);
+        
+        assertNotNull(obj.get("id"));
+
     }
     
     @Test
     public void testImportDb() throws Exception {
-        
-        H2TestData data = new H2TestData();
-        
         Catalog catalog = getCatalog();
         assertNull(catalog.getLayerByName("gs:point"));
-
+        
         Importer importer =
             GeoServerExtensions.bean(Importer.class, applicationContext);
         ImportController ctrl = new ImportController(getGeoServer(), importer);
-
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setContextPath("/geoserver");
-        request.setRequestURI("/geoserver/hello");
-        request.setMethod("post");
         
-        JSONObj obj = data.createConnectionParameters();
-        obj = ctrl.importDb("gs", obj);
-        
-        Long id = Long.parseLong(obj.get("id").toString());
-        assertNotNull(id);
-        JSONArr preimport = obj.array("preimport");
-        assertTrue(3 <= preimport.size());
-        assertEquals(0, obj.array("imported").size());
-        assertEquals(0, obj.array("pending").size());
-        assertEquals(0, obj.array("failed").size());
-        assertEquals(0, obj.array("ignored").size());
-        
-        List<String> names = Arrays.asList(new String[]{"ft1","ft2","ft3"});
-        JSONArr tasks = new JSONArr();
-        for (JSONObj o : preimport.objects()) {
-            if (names.contains(o.get("name"))) {
-                tasks.add(new JSONObj().put("task", o.get("task").toString()));
-                assertEquals("table", o.get("type"));
+        try (H2TestData data = new H2TestData()) {
+            
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setContextPath("/geoserver");
+            request.setRequestURI("/geoserver/hello");
+            request.setMethod("post");
+            
+            JSONObj obj = data.createConnectionParameters();
+            obj = ctrl.importDb("gs", obj, request);
+            
+            Long id = Long.parseLong(obj.get("id").toString());
+            assertNotNull(id);
+            JSONArr preimport = obj.array("preimport");
+            assertTrue(3 <= preimport.size());
+            assertEquals(0, obj.array("imported").size());
+            assertEquals(0, obj.array("pending").size());
+            assertEquals(0, obj.array("failed").size());
+            assertEquals(0, obj.array("ignored").size());
+            
+            //Choose tables to import
+            List<String> names = Arrays.asList(new String[]{"ft1","ft2","ft3"});
+            JSONArr tasks = new JSONArr();
+            for (JSONObj o : preimport.objects()) {
+                if (names.contains(o.get("name"))) {
+                    tasks.add(new JSONObj().put("task", o.get("task").toString()));
+                    assertEquals("table", o.get("type"));
+                }
             }
+            assertEquals(3, tasks.size());
+            JSONObj response = new JSONObj();
+            response.put("tasks", tasks);
+            
+            obj = ctrl.update("gs", id, response);
+            
+            assertEquals(0, obj.array("preimport").size());
+            assertEquals(1, obj.array("imported").size());
+            assertEquals(2, obj.array("pending").size());
+            assertEquals(0, obj.array("failed").size());
+            assertEquals(preimport.size()-3, obj.array("ignored").size());
+            
+            obj = ctrl.get("gs",  id);
+            
+            //Set CRS
+            tasks = new JSONArr();
+            for (JSONObj o : obj.array("pending").objects()) {
+                String srs = "EPSG:4326";
+                tasks.add(new JSONObj().put("task", o.get("task").toString())
+                                       .put("proj", IO.proj(new JSONObj(), CRS.decode(srs), srs)));
+            }
+            response = new JSONObj();
+            response.put("tasks", tasks);
+            
+            obj = ctrl.update("gs", id, response);
+            
+            assertEquals(0, obj.array("preimport").size());
+            assertEquals(3, obj.array("imported").size());
+            assertEquals(0, obj.array("pending").size());
+            assertEquals(0, obj.array("failed").size());
+            assertEquals(preimport.size()-3, obj.array("ignored").size());
+            
+            //Try to reimport the same store - should fail and return existing store
+            obj = data.createConnectionParameters();
+            obj = ctrl.importDb("gs", obj, request);
+            
+            Iterator<String> i = obj.keys().iterator();
+            assertEquals("store", i.next());
+            assertEquals("workspace", i.next());
+            assertEquals("url", i.next());
+            assertFalse(i.hasNext());
         }
-        assertEquals(3, tasks.size());
-        JSONObj response = new JSONObj();
-        response.put("tasks", tasks);
-        
-        obj = ctrl.update("gs", id, response);
-        
-        assertEquals(0, obj.array("preimport").size());
-        assertEquals(1, obj.array("imported").size());
-        assertEquals(2, obj.array("pending").size());
-        assertEquals(0, obj.array("failed").size());
-        assertEquals(preimport.size()-3, obj.array("ignored").size());
-        
-        obj = ctrl.get("gs",  id);
-        
-        data.close();
     }
 
     @Test

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/H2TestData.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/H2TestData.java
@@ -26,7 +26,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import com.boundlessgeo.geoserver.json.JSONObj;
 import com.vividsolutions.jts.io.WKTReader;
 
-public class H2TestData {
+public class H2TestData implements AutoCloseable {
 
     final Logger LOGGER = Logger.getLogger("com.boundlessgeo.geoserver.H2TestData");
     protected DataStore datastore;
@@ -47,10 +47,9 @@ public class H2TestData {
             datastore.removeSchema("ft1");
             datastore.removeSchema("ft2");
             datastore.removeSchema("ft3");
-        } catch (Exception e) {
-          //nothing to remove
+        } finally {
+            datastore.dispose();
         }
-        datastore.dispose();
     }
     
     protected void setUpData() throws Exception {


### PR DESCRIPTION
List of import tasks now contains a geometry attribute for each class. `"geometry":"none"` indicates no valid geometry could be found.

Importer API now tests if a store exists before creating a new one. If a store does exist, the `api/imports POST` will return the store information rather than the import information:

    {
        "store":<store name>
        "workspace":<workspace>
        "url":<store GET url>
    }