### PR TITLE
Copyright Year

### DIFF
--- a/geoserver/webapp/app/components/sidenav/sidenav.js
+++ b/geoserver/webapp/app/components/sidenav/sidenav.js
@@ -22,6 +22,7 @@ angular.module('gsApp.sidenav', [
   function($scope, $rootScope, GeoServer, AppEvent, $state, $log,
     $timeout, $window, AppSession, $location, _, workspacesListModel) {
 
+    $scope.currentYear = new Date();
     $scope.toggleWkspc = {}; // workspaces in wide sidenav
     $scope.toggleWkspc2 = {}; // workspaces in collapse sidenav
 

--- a/geoserver/webapp/app/components/sidenav/sidenav.tpl.html
+++ b/geoserver/webapp/app/components/sidenav/sidenav.tpl.html
@@ -99,7 +99,7 @@
       </a>
     </li>
     <li class="text-center copyright-item">
-      <span class="copyright">&copy; 2014 <a href="http://boundlessgeo.com/site-map/legal/composer-license/">Boundless</a></span>
+      <span class="copyright">&copy; {{currentYear | date:'yyyy'}} <a href="http://boundlessgeo.com/site-map/legal/composer-license/" target="boundlessLicense">Boundless</a></span>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Altering the copyright year to the current system year.
Setting the license link to a new window rather than replacing the Composer interface.