### PR TITLE
Fixed pom repositories

### DIFF
--- a/geoserver/webapp/pom.xml
+++ b/geoserver/webapp/pom.xml
@@ -25,9 +25,26 @@
       <name>Boundless Maven Repository</name>
       <url>http://repo.boundlessgeo.com/main</url>
       <snapshots>
-        <enabled>false</enabled>
+        <enabled>true</enabled>
       </snapshots>
     </repository>
+
+    <repository>
+      <id>geosolutions</id>
+      <name>GeoSolutions Repository</name>
+      <url>http://maven.geo-solutions.it/</url>
+    </repository>
+
+    <repository>
+    <id>osgeo</id>
+    <name>Open Source Geospatial Foundation Repository</name>
+    <url>http://download.osgeo.org/webdav/geotools/</url>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+
+
   </repositories>
 
   <properties>


### PR DESCRIPTION
Added geosolutions and osgeo repositories, and set snapshots to enabled.
These are all required for a successful fresh build of suite. This is often not an issue since developers will often have the necessary dependancies from building geoserver or geotools locally, but blocks building the suite webapp project otherwise.
@mweisman Can you confirm this does not break any existing build steps? I've only tested dev builds.