### PR TITLE
Map + Layer copy API

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
@@ -227,7 +227,7 @@ public class IO {
     public static JSONObj proj(JSONObj obj, CoordinateReferenceSystem crs, String srs) {
         if (srs == null && crs != null) {
             try {
-                srs = CRS.lookupIdentifier(crs, false);
+                srs = CRS.toSRS(crs);
             } catch (Exception e) {
                 LOG.log(Level.WARNING, "Unable to determine srs from crs: " + crs, e);
             }

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/ProjTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/ProjTest.java
@@ -3,6 +3,7 @@
  */
 package com.boundlessgeo.geoserver;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
@@ -20,7 +21,13 @@ public class ProjTest {
 
     @Before
     public void setup() {
+        Proj.INSTANCE = null;
         proj = Proj.get();
+    }
+    
+    @After
+    public void tearDown() {
+        Proj.INSTANCE = null;
     }
 
     @Test
@@ -32,9 +39,10 @@ public class ProjTest {
 
     @Test
     public void testRecent() throws Exception {
-        testCRS();
-
+        
         Map<String,CoordinateReferenceSystem> recent = proj.recent();
+        proj.crs("EPSG:3005");
+        
         assertEquals(3, recent.size());
 
         assertNotNull(recent.get("EPSG:4326"));

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/MapControllerTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/MapControllerTest.java
@@ -145,6 +145,35 @@ public class MapControllerTest {
             assertTrue(e.getMessage().contains("already exists"));
         }
     }
+    
+    @Test
+    public void testCopy() throws Exception {
+        MockGeoServer.get().catalog()
+            .workspace("foo", "http://scratch.org", true)
+                .map("map")
+                  .defaults()
+                  .info("The map", "This map is cool!")
+                  .layer("one").featureType().defaults().store("shape").map()
+                  .layer("two").featureType().defaults().store("shape")
+            .geoServer().build(geoServer);
+        
+        Catalog cat = geoServer.getCatalog();
+        
+        JSONObj obj = new JSONObj();
+        obj.put("name", "bar");
+        obj.put("copylayers", "false");
+        
+        MockHttpServletRequestBuilder req = put("/api/maps/foo/map/copy")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(obj.toString());
+
+        mvc.perform(req)
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        verify(cat, times(1)).add(isA(LayerGroupInfo.class));
+    }
 
     @Test
     public void testList() throws Exception {


### PR DESCRIPTION
Copies an existing map.

* PUT api/maps/\{workspace\}/\{map\}/copy

```
  {"name": "foo",
   "copylayers": "true",
   "layers": [...]
  }
```

Where:
* **name**: The name of the copy
* **copylayers**: Boolean flag to copy all the layers, or use the existing layers in the new map. Optional, defaults to true.
* **layers**: List of layers to rename. Elements have the same syntax as the [Copy Layer API](https://github.com/boundlessgeo/suite/wiki/Layers-API#post). Only applies if `copylayers=true`. If any layers are not provided, renaming defaults to `<oldlayername>-<map>` where `<map>` is the first three letters of the map name.