### PR TITLE
Fixed importer API to allow different database names on the same server

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
@@ -429,6 +429,11 @@ public class ImportController extends ApiController {
             if (p.isRequired() && params.get(p.getName()) != null) {
                 requiredParams.put(p.getName(), params.get(p.getName()));
             }
+            
+        }
+        //Special case to support connections to different databases on the same database server
+        if (params.get("database") != null) {
+            requiredParams.put("database", params.get("database"));
         }
         
         if (!store.getConnectionParameters().containsKey("namespace")) {


### PR DESCRIPTION
If you have two databases with different names on the same database server (Same host, port, user, password), you cannot import both of them into composer. Instead you get the message "This database already exists". This fixes this problem.

@eshon Does this still fit with your vision of one database store per database?