### PR TITLE
Fixed missing resource description in imported layer description

### DIFF
--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -206,7 +206,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
             JSONObj response = new JSONObj();
             response.put("tasks", tasks);
             
-            obj = ctrl.update("gs", id, response);
+            obj = ctrl.update("gs", id, response, request);
             
             assertEquals(0, obj.array("preimport").size());
             assertEquals(1, obj.array("imported").size());
@@ -214,7 +214,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
             assertEquals(0, obj.array("failed").size());
             assertEquals(preimport.size()-3, obj.array("ignored").size());
             
-            obj = ctrl.get("gs",  id);
+            obj = ctrl.get("gs",  id, request);
             
             //Set CRS
             tasks = new JSONArr();
@@ -226,7 +226,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
             response = new JSONObj();
             response.put("tasks", tasks);
             
-            obj = ctrl.update("gs", id, response);
+            obj = ctrl.update("gs", id, response, request);
             
             assertEquals(0, obj.array("preimport").size());
             assertEquals(3, obj.array("imported").size());


### PR DESCRIPTION
The resource description was missing from the Importer API response for a sucessfully imported layer.
Store details for an imported layer can now be found in the Import API response under "resource":

```
{
  "id": 0, 
  "preimport": [],
  "imported": [
    {
      "task": 0, 
      "name": "stipple.shp",
      "type": "file"
      "layer": {
        "name": "stipple", 
        "workspace": "opengeo",
        "resource": {
          store:"FOSS4G2015"
          workspace:"test"
          ...
        }
      }
    }
  ]
}
```