### PR TITLE
Fixed IO.proj failure on complex srs

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
@@ -277,7 +277,7 @@ public class IO {
                 units = crs instanceof ProjectedCRS ? "m" : "degrees";
             }
             obj.put("unit", units);
-            obj.put("wkt", crs.toWKT());
+            obj.put("wkt", crs.toString());
         }
 
         return obj;

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/IOTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/IOTest.java
@@ -1,0 +1,30 @@
+package com.boundlessgeo.geoserver.api.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import com.boundlessgeo.geoserver.Proj;
+import com.boundlessgeo.geoserver.json.JSONObj;
+
+public class IOTest {
+
+    @Test
+    public void TestProj() {
+        
+        //Test regurlar CRS
+        String srs = "EPSG:4326";
+        JSONObj obj = new JSONObj();
+        IO.proj(obj, Proj.get().crs(srs), srs);
+        assertEquals(srs, obj.str("srs"));
+        assertNotNull(obj.get("wkt"));
+        //Test complex CRS (Polar)
+        srs = "EPSG:3031";
+        obj = new JSONObj();
+        IO.proj(obj, Proj.get().crs(srs), srs);
+        assertEquals(srs, obj.str("srs"));
+        assertNotNull(obj.get("wkt"));
+    }
+
+}


### PR DESCRIPTION
Formattable.toString() has less strict syntax checking, and is what is used by geoserver. Also added test case for IO.java