### PR TITLE
Added canonical projection extent to map GET and layer GET

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/MapController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/MapController.java
@@ -527,8 +527,8 @@ public class MapController extends ApiController {
            .put("description", map.getAbstract());
         ReferencedEnvelope bounds = map.getBounds();
         IO.proj(obj.putObject("proj"), bounds.getCoordinateReferenceSystem(), null);
-        IO.bounds(obj.putObject("bbox"), (Envelope)bounds);
-        IO.bounds(obj.putObject("extent"), CRS.getEnvelope(bounds.getCoordinateReferenceSystem()));
+        IO.bounds(obj.putObject("bbox"), bounds);
+        IO.bounds(obj.putObject("projectionExtent"), CRS.getEnvelope(bounds.getCoordinateReferenceSystem()));
         obj.put("layer_count", map.getLayers().size());
 
         IO.metadata(obj, map);

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/MapController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/MapController.java
@@ -527,7 +527,8 @@ public class MapController extends ApiController {
            .put("description", map.getAbstract());
         ReferencedEnvelope bounds = map.getBounds();
         IO.proj(obj.putObject("proj"), bounds.getCoordinateReferenceSystem(), null);
-        IO.bounds(obj.putObject("bbox"), bounds);
+        IO.bounds(obj.putObject("bbox"), (Envelope)bounds);
+        IO.bounds(obj.putObject("extent"), CRS.getEnvelope(bounds.getCoordinateReferenceSystem()));
         obj.put("layer_count", map.getLayers().size());
 
         IO.metadata(obj, map);


### PR DESCRIPTION
Map and Layer get requests now include an object named "extent" with the cannonical projection extent of the CRS of that map or layer. Object format is same as map bounds:

```
"extent":
    {
          "center": [0, 0], 
          "south": -90, 
          "north": 90, 
          "east": -180, 
          "west": -180
    }
```