### PR TITLE
ImportController and test fixes

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
@@ -99,7 +99,6 @@ public class ImportController extends ApiController {
         // pass off the uploaded file(s) to the importer
         Directory dir = new Directory(uploadDir);
         while(files.hasNext()) {
-            //TODO: Validate input?
             dir.accept(files.next());
         }
         
@@ -257,6 +256,12 @@ public class ImportController extends ApiController {
         // 2. mark layers as "imported" so we can safely delete styles later
         
         LayerInfo l = t.getLayer();
+        
+        //If the task has no associated layer, it is probably a junk file that won't get imported
+        if (l == null) {
+            return;
+        }
+        
         l.getMetadata().put(Metadata.IMPORTED, new Date());
 
         if (l != null && l.getDefaultStyle() != null) {

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -190,7 +190,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
                 IOUtils.toByteArray(getClass().getResourceAsStream("point.prj")));
         appendMultiPartFormContent(body, "form-data; name=\"upload\"; filename=\"point.shp\"", "application/octet-stream",
                 IOUtils.toByteArray(getClass().getResourceAsStream("point.shp")));
-        appendMultiPartFormContent(body, "form-data; name=\"upload\"; filename=\"point.shz\"", "application/octet-stream",
+        appendMultiPartFormContent(body, "form-data; name=\"upload\"; filename=\"point.shx\"", "application/octet-stream",
                 IOUtils.toByteArray(getClass().getResourceAsStream("point.shx")));
         
         createMultiPartFormContent(body, request);


### PR DESCRIPTION
Fixes issues identified in #899 

NPE caused by prepTask on a task without a layer (eg invalid file) fixed.
Typo in test cases fixed

Validation of data handled by importer (Note that Importer accepts .shp without .dbf as valid).
Validation of files will be handled front-end.