### PR TITLE
Added defaultGeometry to resource/schema API

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
@@ -555,6 +555,9 @@ public class IO {
             schema.put("name", type.getName().getLocalPart() );
             schema.put("namespace", type.getName().getNamespaceURI() );
             schema.put("simple", type instanceof SimpleFeatureType );
+            if (null != type.getGeometryDescriptor()) {
+                schema.put("defaultGeometry", type.getGeometryDescriptor().getName().getLocalPart());
+            }
             JSONArr attributes = schema.putArray("attributes");
             for( PropertyDescriptor d : type.getDescriptors() ){
                 PropertyType t = d.getType();
@@ -578,7 +581,7 @@ public class IO {
                     .put("type", t.getBinding().getSimpleName() );
                 
                 if( d instanceof GeometryDescriptor){
-                    GeometryDescriptor g = (GeometryDescriptor) d;                    
+                    GeometryDescriptor g = (GeometryDescriptor) d;
                     proj( property.putObject("proj"), g.getCoordinateReferenceSystem(), null );
                 }
 

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/IOTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/IOTest.java
@@ -3,10 +3,13 @@ package com.boundlessgeo.geoserver.api.controllers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.junit.Test;
-
+import org.opengis.feature.simple.SimpleFeatureType;
 import com.boundlessgeo.geoserver.Proj;
 import com.boundlessgeo.geoserver.json.JSONObj;
+import com.vividsolutions.jts.geom.Point;
 
 public class IOTest {
 
@@ -26,5 +29,22 @@ public class IOTest {
         assertEquals(srs, obj.str("srs"));
         assertNotNull(obj.get("wkt"));
     }
-
+    
+    @Test
+    public void TestSchema() {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("test_schema");
+        builder.setCRS(DefaultGeographicCRS.WGS84);
+        
+        builder.add("the_geom", Point.class);
+        builder.add("other_geom", Point.class);
+        builder.setDefaultGeometry("other_geom");
+        builder.length(15).add("name", String.class);
+        
+        final SimpleFeatureType type = builder.buildFeatureType();
+        
+        JSONObj schema = IO.schema(new JSONObj(), type, false);
+        assertEquals("test_schema", schema.get("name"));
+        assertEquals("other_geom", schema.get("defaultGeometry"));
+    }
 }


### PR DESCRIPTION
`defaultGeometry` is now an attribute under the resource `schema` object, and lists the name of the default geometry