### PR TITLE
Thumbnails API and Support

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/AppConfiguration.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/AppConfiguration.java
@@ -1,0 +1,109 @@
+/* (c) 2015 Boundless, http://boundlessgeo.com
+ * This code is licensed under the GPL 2.0 license.
+ */
+package com.boundlessgeo.geoserver;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.servlet.ServletContext;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.config.GeoServerDataDirectory;
+import org.geoserver.platform.GeoServerExtensions;
+import org.geotools.util.logging.Logging;
+import org.springframework.web.context.ServletContextAware;
+
+/**
+ * Tracks boundless suite specific configuration data:
+ * * Composer cache directory, used for storing cached thumbnails. 
+ *   Refer to {@link #lookupCacheDirectory(ServletContext)} for how this location is generated.
+ */
+public class AppConfiguration implements ServletContextAware {
+    Catalog catalog;
+    ServletContext servletContext;
+    
+    private String cacheDir;
+    
+    private static Logger LOGGER = Logging.getLogger(AppConfiguration.class);
+    
+    public AppConfiguration(Catalog catalog) {
+        this.catalog = catalog;
+    }
+    
+    /**
+     * Determines the location of the composer thumbnail cache directory by running a property 
+     * lookup on COMPOSER_CACHE_DIR. If this property is not found, uses the default value of 
+     * GEOSERVER_DATA_DIR/composer
+     * 
+     * @param servContext The servlet context.
+     * @return String The absolute path to the data directory, or <code>null</code> if it could not
+     * be found. 
+     */
+    private String lookupCacheDirectory(ServletContext servContext) {
+        
+        //Try property lookup
+        String cacheDir = GeoServerExtensions.getProperty("COMPOSER_CACHE_DIR", servContext);
+        
+        //Use the default of data/composer
+        if(cacheDir == null) {
+            cacheDir = (GeoServerExtensions.bean(GeoServerDataDirectory.class).root().getPath())
+                    +File.separator+"composer";
+        }
+        try {
+            File cacheFile = new File(cacheDir);
+            if (!cacheFile.exists()) {
+                cacheFile.mkdirs();
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Could not initilize composer cache directory", e);
+        }
+        return cacheDir;
+    }
+    
+    @Override
+    public void setServletContext(ServletContext servletContext) {
+        this.servletContext = servletContext;
+        cacheDir = lookupCacheDirectory(servletContext);
+    }
+
+    /**
+     * Returns the location of the composer cache directory
+     * @return Path to the composer cache directory
+     */
+    public String getCacheDir() {
+        return cacheDir;
+    }
+    
+    /**
+     * Retrieves a file from the cache directory denoted by a relative path. 
+     * If the file does not exist, creates a new file.
+     * @param path relative path within cache dir
+     * @return the file
+     * @throws IOException if there is an error creating the file
+     */
+    public File createCacheFile(String path) throws IOException {
+        File file = new File(cacheDir + File.separator + path);
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        return file;
+    }
+    /**
+     * Retrieves a file from the cache directory denoted by a relative path. 
+     * If the file does not exist, throws a FileNotFoundException
+     * @param path relative path within cache dir
+     * @return the file
+     * @throws FileNotFoundException if the file does not exist
+     */
+    public File getCacheFile(String path) throws FileNotFoundException {
+        File file = new File(cacheDir + File.separator + path);
+        if (!file.exists()) {
+            throw new FileNotFoundException(cacheDir + File.separator + path);
+        }
+        return file;
+    }
+}

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/Metadata.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/Metadata.java
@@ -5,6 +5,7 @@ package com.boundlessgeo.geoserver.api.controllers;
 
 import org.geoserver.catalog.Info;
 import org.geoserver.catalog.MetadataMap;
+import org.geoserver.catalog.PublishedInfo;
 import org.geoserver.ows.util.OwsUtils;
 import org.geotools.util.Converters;
 
@@ -18,7 +19,22 @@ public class Metadata {
     static final String CREATED = "created";
     static final String MODIFIED = "modified";
     static final String IMPORTED = "imported";
-
+    
+    public static final String THUMBNAIL = "thumbnail";
+    
+    //Relative thumbnail location
+    public static void thumbnail(PublishedInfo obj, String path) {
+        map(obj).put(THUMBNAIL, path);
+    }
+    
+    public static String thumbnail(PublishedInfo obj) {
+        return (String)map(obj).get(THUMBNAIL);
+    }
+    
+    public static void invalidateThumbnail(PublishedInfo layer) {
+        Metadata.map(layer).remove(Metadata.THUMBNAIL);
+    }
+    
     public static void created(Info obj, Date created) {
         MetadataMap map = map(obj);
         map.put(CREATED, created);

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ThumbnailController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ThumbnailController.java
@@ -1,0 +1,333 @@
+/* (c) 2015 Boundless, http://boundlessgeo.com
+ * This code is licensed under the GPL 2.0 license.
+ */
+package com.boundlessgeo.geoserver.api.controllers;
+
+import java.awt.geom.AffineTransform;
+import java.awt.image.AffineTransformOp;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.imageio.ImageIO;
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.io.IOUtils;
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.LayerGroupHelper;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.PublishedInfo;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.WorkspaceInfo;
+import org.geoserver.config.GeoServer;
+import org.geoserver.wms.GetMapRequest;
+import org.geoserver.wms.MapLayerInfo;
+import org.geoserver.wms.WebMap;
+import org.geoserver.wms.WebMapService;
+import org.geoserver.wms.map.RenderedImageMap;
+import org.geotools.styling.Style;
+import org.geotools.util.logging.Logging;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.boundlessgeo.geoserver.AppConfiguration;
+import com.google.common.util.concurrent.Striped;
+import com.vividsolutions.jts.geom.Envelope;
+
+@Controller
+@RequestMapping("/api/thumbnails")
+public class ThumbnailController extends ApiController {
+    
+    private static Logger LOG = Logging.getLogger(ThumbnailController.class);
+    static final String TYPE = "png";
+    static final String MIME_TYPE = "image/png";
+    public static final String EXTENSION = ".png";
+    public static final String EXTENSION_HR = "@2x.png";
+    public static final int THUMBNAIL_SIZE = 75;
+    
+    @Autowired
+    @Qualifier("wmsServiceTarget")
+    WebMapService wms;
+    
+    @Autowired
+    AppConfiguration config;
+    
+    Striped<Semaphore> semaphores = Striped.semaphore(4, 1);
+    
+    @Autowired
+    public ThumbnailController(GeoServer geoServer) {
+        super(geoServer);
+    }
+    
+    /**
+     * Endpoint to retrieve a cached thumbnail for a map, generating it if it does not exist.
+     * If the request parameter "hiRes=true" is provided, returns a high-resolution (x2) thumbnail.
+     * @param wsName Workspace name
+     * @param name Map name
+     * @param hiRes Whether or not to return a high-res thumbnail. Optional, defaults to false
+     * @param request
+     * @return HttpEntity containing the thumbnail image as a byte array
+     * @throws Exception
+     */
+    @RequestMapping(value = "/maps/{wsName:.+}/{name:.+}", method = RequestMethod.GET)
+    public HttpEntity<byte[]> getMap(@PathVariable String wsName, 
+            @PathVariable String name, 
+            @RequestParam(value="hiRes", required=false, defaultValue="false") Boolean hiRes,
+            HttpServletRequest request) throws Exception {
+        
+        Catalog catalog = geoServer.getCatalog();
+        WorkspaceInfo ws = findWorkspace(wsName, catalog);
+        LayerGroupInfo map = findMap(wsName, name, catalog);
+        
+        return get(ws, map, hiRes);
+    }
+    
+    /**
+     * Endpoint to retrieve a cached thumbnail for a layer, generating it if it does not exist.
+     * If the request parameter "hiRes=true" is provided, returns a high-resolution (x2) thumbnail.
+     * @param wsName Workspace name
+     * @param name Layer name
+     * @param hiRes Whether or not to return a high-res thumbnail. Optional, defaults to false
+     * @param request
+     * @return HttpEntity containing the thumbnail image as a byte array
+     * @throws Exception
+     */
+    @RequestMapping(value = "/layers/{wsName:.+}/{name:.+}", method = RequestMethod.GET)
+    public HttpEntity<byte[]> getLayer(@PathVariable String wsName, 
+            @PathVariable String name, 
+            @RequestParam(value="hiRes", required=false, defaultValue="false") Boolean hiRes,
+            HttpServletRequest request) throws Exception {
+        
+        Catalog catalog = geoServer.getCatalog();
+        WorkspaceInfo ws = findWorkspace(wsName, catalog);
+        LayerInfo layer = findLayer(wsName, name, catalog);
+        
+        return get(ws, layer, hiRes);
+    }
+    
+    /**
+     * Retrieve or create the thumbnail for a PublishedInfo
+     * @param ws Workspace for the layer
+     * @param layer LayerInfo or LayerGroupInfo to get the thumbnail of
+     * @param hiRes Flag to return hi-res (x2) thumbnail
+     * @return HttpEntity containing the thumbnail image as a byte array
+     * @throws Exception
+     */
+    public HttpEntity<byte[]> get(WorkspaceInfo ws, PublishedInfo layer, boolean hiRes) throws Exception {
+        String path = Metadata.thumbnail(layer);
+        FileInputStream in = null;
+        
+        //Has not been generated yet, use WMS reflector
+        if (path == null) {
+            createThumbnail(ws, layer);
+            path = Metadata.thumbnail(layer);
+        }
+        File thumbnailFile;
+        //If the file has been deleted, recreate it
+        try {
+            thumbnailFile = config.getCacheFile(path);
+        } catch (FileNotFoundException e) {
+            createThumbnail(ws, layer);
+            path = Metadata.thumbnail(layer);
+        }
+        try {
+            if (hiRes) {
+                thumbnailFile = config.getCacheFile(path.replaceAll(
+                        EXTENSION+"$", EXTENSION_HR));
+            } else {
+                thumbnailFile = config.getCacheFile(path);
+            }
+            in = new FileInputStream(thumbnailFile);
+            byte[] bytes = IOUtils.toByteArray(in);
+            final HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType(MIME_TYPE));
+            headers.setLastModified(thumbnailFile.lastModified());
+            return new HttpEntity<byte[]>(bytes, headers);
+        } finally {
+            if (in != null) { in.close(); }
+        }
+    }
+    
+    /**
+     * Creates a thumbnail for the layer as a Resource, and updates the layer with the new thumbnail
+     * @param ws The workspace of the layer
+     * @param layer The layer or layerGroup to get the thumbnail for
+     * @return The thumbnail image as a Resource
+     * @throws Exception
+     */
+    protected void createThumbnail(WorkspaceInfo ws, PublishedInfo layer) throws Exception {
+        Catalog catalog = geoServer.getCatalog();
+        //Sync against this map/layer
+        Semaphore s = semaphores.get(layer);
+        s.acquire();
+        try {
+            //Set up getMap request
+            GetMapRequest request = new GetMapRequest();
+            
+            List<MapLayerInfo> layers = new ArrayList<MapLayerInfo>();
+            List<Style> styles = new ArrayList<Style>();
+            Envelope bbox = null;
+            if (layer instanceof LayerInfo) {
+                layers.add(new MapLayerInfo((LayerInfo)layer));
+                styles.add(((LayerInfo)layer).getDefaultStyle().getStyle());
+                bbox = ((LayerInfo)layer).getResource().boundingBox();
+            } else if (layer instanceof LayerGroupInfo) {
+                LayerGroupHelper helper = new LayerGroupHelper((LayerGroupInfo)layer);
+                bbox = ((LayerGroupInfo)layer).getBounds();
+                
+                List<LayerInfo> layerList = helper.allLayersForRendering();
+                for (int i = 0; i  < layerList.size(); i++) {
+                    layers.add(new MapLayerInfo(layerList.get(i)));
+                }
+                List<StyleInfo> styleList = helper.allStylesForRendering();
+                for (int i = 0; i  < styleList.size(); i++) {
+                    if (styleList.get(i) == null) {
+                        styles.add(layerList.get(i).getDefaultStyle().getStyle());
+                    } else {
+                        styles.add(styleList.get(i).getStyle());
+                    }
+                }
+            } else {
+                throw new RuntimeException("layer must be one of LayerInfo or LayerGroupInfo");
+            }
+            request.setLayers(layers);
+            request.setStyles(styles);
+            request.setFormat(MIME_TYPE);
+            
+            //Set the size of the HR thumbnail
+            //Take the smallest bbox dimension as the min dimension. We can then crop the other 
+            //dimension to give a square thumbnail
+            request.setBbox(bbox);
+            if (bbox.getWidth() < bbox.getHeight()) {
+                request.setWidth(2*THUMBNAIL_SIZE);
+            } else {
+                request.setHeight(2*THUMBNAIL_SIZE);
+            }
+            
+            //Run the getMap request through the WMS Reflector
+            WebMap response = wms.reflect(request);
+            //Get the resulting map image
+            BufferedImage image;
+            if (response instanceof RenderedImageMap) {
+                RenderedImageMap map = (RenderedImageMap)response;
+                assert(map.getImage() instanceof BufferedImage);
+                image = (BufferedImage)map.getImage();
+            } else {
+                throw new RuntimeException("Unsupported getMap response format:" + response.getClass().getName());
+            }
+            
+            writeThumbnail(layer, image);
+            Metadata.thumbnail(layer, thumbnailFilename(layer));
+            
+            if (layer instanceof LayerInfo) {
+                catalog.save((LayerInfo)layer);
+            } else if (layer instanceof LayerGroupInfo) {
+                catalog.save((LayerGroupInfo)layer);
+            }
+        } finally {
+            s.release();
+        }
+    }
+    
+    protected void writeThumbnail(PublishedInfo layer, BufferedImage image) throws FileNotFoundException, IOException, InterruptedException {
+      //Write the thumbnail files
+        FileOutputStream loRes = null;
+        FileOutputStream hiRes = null;
+        
+        try {
+            loRes = new FileOutputStream(config.createCacheFile(thumbnailFilename(layer)));
+            hiRes = new FileOutputStream(config.createCacheFile(thumbnailFilename(layer, true)));
+            
+            ImageIO.write(scaleImage(image, 0.5, true), TYPE, loRes);
+            //Don't scale, but crop to square
+            ImageIO.write(scaleImage(image, 1.0, true), TYPE, hiRes);
+        } finally {
+            if (loRes != null) { 
+                try {
+                    loRes.close(); 
+                } catch (IOException e) {
+                    LOG.log(Level.WARNING, "Error closing file", e);
+                }
+            }
+            if (hiRes != null) { 
+                try {
+                    hiRes.close();
+                } catch (IOException e) {
+                    LOG.log(Level.WARNING, "Error closing file", e);
+                }
+            }
+        }
+    }
+    /**
+     * Utility method to generate a consistent thumbnail filename
+     * @param layer to create the filename for
+     * @return relative filename
+     */
+    public static final String thumbnailFilename(PublishedInfo layer) {
+        return thumbnailFilename(layer, false);
+    }
+    
+    /**
+     * Utility method to generate a consistent thumbnail filename
+     * @param layer to create the filename for
+     * @param hiRes is this the name of a hi-res thumbnail file?
+     * @return relative filename
+     */
+    public static final String thumbnailFilename(PublishedInfo layer, boolean hiRes) {
+        if (hiRes) {
+            return layer.getId()+EXTENSION_HR;
+        }
+        return layer.getId()+EXTENSION;
+    }
+    
+    public static RenderedImage scaleImage(BufferedImage image, double scale) throws IOException {
+        return scaleImage(image, scale, false);
+    }
+    /**
+     * Utility method for scaling thumbnails. Scales byte[] image by a scale factor.
+     * Optionally crops images to square.
+     * @param src RenderedImage containing the input image
+     * @param scale Scale amount
+     * @param square Boolean flag to crop to a square image
+     * @return RenderedImage containing the transformed image
+     * @throws IOException
+     */
+    public static BufferedImage scaleImage(BufferedImage image, double scale, boolean square) throws IOException {
+        BufferedImage scaled = image;
+        if (scale != 1.0) {
+            AffineTransform scaleTransform = AffineTransform.getScaleInstance(scale, scale);
+            AffineTransformOp bilinearScaleOp = new AffineTransformOp(scaleTransform, AffineTransformOp.TYPE_BILINEAR);
+            scaled =  bilinearScaleOp.filter(image, new BufferedImage(
+                    (int)(image.getWidth()*scale), (int)(image.getHeight()*scale), image.getType()));
+        }
+        if (square) {
+            if (scaled.getHeight() > scaled.getWidth()) {
+                scaled = scaled.getSubimage(0, (scaled.getHeight() - scaled.getWidth())/2, 
+                                            scaled.getWidth(), scaled.getWidth());
+            } else if (scaled.getHeight() < scaled.getWidth()) {
+                scaled = scaled.getSubimage((scaled.getWidth() - scaled.getHeight())/2, 0,
+                                            scaled.getHeight(), scaled.getHeight());
+            }
+        }
+        
+        return scaled;
+    }
+}

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/catalog/ThumbnailInvalidatingCatalogListener.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/catalog/ThumbnailInvalidatingCatalogListener.java
@@ -1,0 +1,201 @@
+/* (c) 2015 Boundless, http://boundlessgeo.com
+ * This code is licensed under the GPL 2.0 license.
+ */
+package com.boundlessgeo.geoserver.catalog;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
+import org.geoserver.catalog.MetadataMap;
+import org.geoserver.catalog.StyleInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+
+import com.boundlessgeo.geoserver.api.controllers.Metadata;
+
+/**
+ * Removes thumbnail metadata from LayerInfo and LayerGroupInfo objects when those objects or any
+ * StyleInfo objects they depend upon are changed. This ensures the thumbnail listed in the metadata
+ * is always up to date.
+ *
+ */
+public class ThumbnailInvalidatingCatalogListener implements CatalogListener {
+    Catalog catalog;
+    //Prevent recursion
+    private boolean modifying = false;
+    
+    public ThumbnailInvalidatingCatalogListener(Catalog catalog) {
+        this.catalog = catalog;
+        catalog.addListener(this);
+    }
+    
+    @Override
+    public void handleAddEvent(CatalogAddEvent event) throws CatalogException {
+        //No change on add, as thumbnails will not have been generated yet
+    }
+
+    @Override
+    public void handleRemoveEvent(CatalogRemoveEvent event)
+            throws CatalogException {
+        CatalogInfo source = event.getSource();
+        
+        //If we delete a style or layer used by a layer or map, invalidate upstream thumbnails
+        if (!modifying) {
+            try {
+                modifying = true;
+                if (source instanceof StyleInfo) {
+                    //Invalidate any maps or layers using this style
+                    for (LayerInfo layer : catalog.getLayers()) {
+                        if (source.equals(layer.getDefaultStyle())) {
+                            Metadata.invalidateThumbnail(layer);
+                            catalog.save(layer);
+                        }
+                    }
+                    for (LayerGroupInfo layerGroup : catalog.getLayerGroups()) {
+                        if (layerGroup.getStyles().contains(source)) {
+                            Metadata.invalidateThumbnail(layerGroup);
+                            catalog.save(layerGroup);
+                        }
+                    }
+                } else if(source instanceof LayerInfo) {
+                    LayerInfo layer = catalog.getLayer(source.getId());
+                    Metadata.invalidateThumbnail(layer);
+                    catalog.save(layer);
+                    //Invalidate any maps using this layer
+                    for (LayerGroupInfo layerGroup : catalog.getLayerGroups()) {
+                        if (layerGroup.getLayers().contains(source)) {
+                            Metadata.invalidateThumbnail(layerGroup);
+                            catalog.save(layerGroup);
+                        }
+                    }
+                } else if (source instanceof LayerGroupInfo) {
+                    LayerGroupInfo layerGroup = catalog.getLayerGroup(source.getId());
+                    Metadata.invalidateThumbnail(layerGroup);
+                    catalog.save(layerGroup);
+                }
+            } finally {
+                modifying = false;
+            }
+        }
+    }
+    
+    /**
+     * Invalidates all thumbnails that depend on the modified resources, by removing the thumbnail 
+     * entry from the associated metadata map. Only affects LayerInfo and LayerGroupInfo objects, 
+     * and only runs for StyleInfo, LayerInfo, or LayerGroupInfo objects.
+     * If the event updates the thumbnail entry, this new value is preserved for the source object, 
+     * but the thumbnails for all dependent objects are still invalidated.
+     */
+    @Override
+    public void handleModifyEvent(CatalogModifyEvent event)
+            throws CatalogException {
+        //Handle all modifications postModify, so metadata is updated correctly
+        
+        CatalogInfo source = event.getSource();
+        
+        if (!modifying) {
+            try {
+                modifying = true;
+                if (source instanceof StyleInfo) {
+                    //Invalidate any maps or layers using this style
+                    for (LayerInfo layer : catalog.getLayers()) {
+                        if (source.equals(layer.getDefaultStyle())) {
+                            Metadata.invalidateThumbnail(layer);
+                            catalog.save(layer);
+                        }
+                    }
+                    for (LayerGroupInfo layerGroup : catalog.getLayerGroups()) {
+                        if (layerGroup.getStyles().contains(source)) {
+                            Metadata.invalidateThumbnail(layerGroup);
+                            catalog.save(layerGroup);
+                        }
+                    }
+                } else if(source instanceof LayerInfo) {
+                    //Invalidate layer, plus any maps using this layer
+                    if (!updateThumbnailEvent(event)) {
+                        LayerInfo layer = catalog.getLayer(source.getId());
+                        Metadata.invalidateThumbnail(layer);
+                        catalog.save(layer);
+                    }
+                    for (LayerGroupInfo layerGroup : catalog.getLayerGroups()) {
+                        if (layerGroup.getLayers().contains(source)) {
+                            Metadata.invalidateThumbnail(layerGroup);
+                            catalog.save(layerGroup);
+                        }
+                    }
+                } else if (source instanceof LayerGroupInfo) {
+                    //Only invalidate map
+                    if (!updateThumbnailEvent(event)) {
+                        LayerGroupInfo layerGroup = catalog.getLayerGroup(source.getId());
+                        Metadata.invalidateThumbnail(layerGroup);
+                        catalog.save(layerGroup);
+                    }
+                }
+            } finally {
+                modifying = false;
+            }
+        }
+        
+    }
+    
+    /* 
+     * Determines if this event changes the thumbnail entry in the metadata map. If so returns true,
+     * otherwise returns false.
+     * 
+     * If the event modifies the metadata map, and the metadata map contains a thumbnail entry that 
+     * is not changed, invalidates the thumbnail entry by removing it from the metadata map.
+     */
+    private boolean updateThumbnailEvent(CatalogModifyEvent event) {
+        for (int i = 0; i < event.getNewValues().size(); i++) {
+            if (event.getNewValues().get(i) instanceof MetadataMap) {
+                MetadataMap oldMap = (MetadataMap)event.getOldValues().get(i);
+                MetadataMap newMap = (MetadataMap)event.getNewValues().get(i);
+                
+                if (updateMetadataMap(oldMap, newMap)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    /* 
+     * Determines if the metadata maps contain thumbnail entries and if the entries are different.
+     * If so returns true, otherwise returns false.
+     * 
+     * If both maps contain thumbnail entries that are identical, 
+     * this method removes the thumbnail entry from newMap.
+     */
+    protected static boolean updateMetadataMap(MetadataMap oldMap, MetadataMap newMap) {
+        //Modify thumbnail entry
+        if (oldMap.containsKey(Metadata.THUMBNAIL) && newMap.containsKey(Metadata.THUMBNAIL)
+                && !oldMap.get(Metadata.THUMBNAIL).equals(newMap.get(Metadata.THUMBNAIL)) ) {
+            return true;
+        }
+        //Add or remove thumbnail entry
+        if ((oldMap.containsKey(Metadata.THUMBNAIL) && !newMap.containsKey(Metadata.THUMBNAIL))
+                || (!oldMap.containsKey(Metadata.THUMBNAIL) && newMap.containsKey(Metadata.THUMBNAIL))) {
+            return true;
+        }
+        //If the metadata map changes but the thumbnail does not, remove the thumbnail 
+        //from the map to invalidate it.
+        if (oldMap.containsKey(Metadata.THUMBNAIL) && newMap.containsKey(Metadata.THUMBNAIL)
+                && oldMap.get(Metadata.THUMBNAIL).equals(newMap.get(Metadata.THUMBNAIL)) ) {
+            newMap.remove(Metadata.THUMBNAIL);
+        }
+        return false;
+    }
+
+    @Override
+    public void handlePostModifyEvent(CatalogPostModifyEvent event)
+            throws CatalogException { }
+
+    @Override
+    public void reloaded() { }
+
+}

--- a/geoserver/webapp/src/main/resources/applicationContext.xml
+++ b/geoserver/webapp/src/main/resources/applicationContext.xml
@@ -31,6 +31,15 @@
         <property name="beanId" value="layerListDemo2"/>
     </bean>
     
+    <!-- configure thumbnail cache -->
+    <bean id="config" class="com.boundlessgeo.geoserver.AppConfiguration">
+      <constructor-arg ref="catalog"/>
+    </bean>
+    
+    <bean class="com.boundlessgeo.geoserver.catalog.ThumbnailInvalidatingCatalogListener">
+      <constructor-arg ref="catalog"/>
+    </bean>
+    
     <!-- configure FTL template loading path -->
     <bean class="org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer">
       <property name="templateLoaderPath" value="/WEB-INF/ftl/"/>

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/catalog/ThumbnailInvalidatingCatalogListenerTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/catalog/ThumbnailInvalidatingCatalogListenerTest.java
@@ -1,0 +1,37 @@
+package com.boundlessgeo.geoserver.catalog;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static com.boundlessgeo.geoserver.catalog.ThumbnailInvalidatingCatalogListener.updateMetadataMap;
+
+import org.geoserver.catalog.MetadataMap;
+import org.junit.Test;
+
+import com.boundlessgeo.geoserver.api.controllers.Metadata;
+
+public class ThumbnailInvalidatingCatalogListenerTest {
+    
+    @Test
+    public void testUpdateMetadataMap() {
+        MetadataMap oldMap = new MetadataMap();
+        MetadataMap newMap = new MetadataMap();
+        
+        //Not in either - No change to metadata map, but should continue invalidation
+        assertFalse(updateMetadataMap(oldMap, newMap));
+        
+        //Only in newMap - Adding thumbnail metadata
+        newMap.put(Metadata.THUMBNAIL, "test");
+        
+        assertTrue(updateMetadataMap(oldMap, newMap));
+        
+        //Both the same - Should remove from newMap
+        oldMap.put(Metadata.THUMBNAIL, "test");
+        
+        assertFalse(updateMetadataMap(oldMap, newMap));
+        assertFalse(newMap.containsKey(Metadata.THUMBNAIL));
+        
+        //Only in oldMap - removing thumbnail metadata
+        assertTrue(updateMetadataMap(oldMap, newMap));
+    }
+
+}

--- a/geoserver/webapp/src/test/resources/com/boundlessgeo/geoserver/point.sld
+++ b/geoserver/webapp/src/test/resources/com/boundlessgeo/geoserver/point.sld
@@ -1,0 +1,28 @@
+<StyledLayerDescriptor version="1.0.0" 
+    xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+    xmlns="http://www.opengis.net/sld" 
+    xmlns:ogc="http://www.opengis.net/ogc" 
+    xmlns:xlink="http://www.w3.org/1999/xlink" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>Simple Point</Name>
+    <UserStyle>
+      <Title>SLD Cook Book: Simple Point</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
This pull request constitues a collection of interdependant classes for caching and serving thumbnails of maps and layers:
* ThumbnailController.java provides an API endpoint for retrieving thumbnails and generates thumbnails if they do not exist.
* AppConfiguration.java tracks the location of the cached thumbnail files, and allows this location to be configured similar to the geoserver data directory. (The idea is to add to this class if similar configuration elements are required in the future)
* ComposerOutputFormat.java extends the regular PNG getMap format to add support for saving thumbnails and bounding boxes.
* ThumbnailInvalidatingCatalogListener listens to catalog events and invalidated thumbnail entries to the metadata maps if resources are changed without their thumbnails being updated.

A faitly extensinve integration test touching on all these components has been added to AppIntegrationTest.java