### PR TITLE
Use UploadDeleteCatalogListener to delete uploaded files

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/StoreController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/StoreController.java
@@ -150,16 +150,6 @@ import com.boundlessgeo.geoserver.json.JSONObj;
             }
             throw new IllegalStateException( message.toString() );
         }
-        try {
-            // If this store is file based, and was uploaded using this API or the REST upload API,
-            // delete the uploaded file.
-            java.io.File uploadDir = ImportController.uploadDir(cat, store.getWorkspace(), store);
-            if (uploadDir.exists()) {
-                Files.delete(uploadDir);
-            }
-        } catch (IOException e) {
-            throw new RuntimeException("Could not delete store files for "+name, e);
-        }
         
         JSONObj json = new JSONObj();
         json.put("name", name  )

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/catalog/UploadDeleteCatalogListener.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/catalog/UploadDeleteCatalogListener.java
@@ -1,0 +1,66 @@
+/* (c) 2015 Boundless, http://boundlessgeo.com
+ * This code is licensed under the GPL 2.0 license.
+ */
+package com.boundlessgeo.geoserver.catalog;
+
+import java.io.IOException;
+
+import org.geoserver.catalog.Catalog;
+import org.geoserver.catalog.CatalogException;
+import org.geoserver.catalog.CatalogInfo;
+import org.geoserver.catalog.StoreInfo;
+import org.geoserver.catalog.event.CatalogAddEvent;
+import org.geoserver.catalog.event.CatalogListener;
+import org.geoserver.catalog.event.CatalogModifyEvent;
+import org.geoserver.catalog.event.CatalogPostModifyEvent;
+import org.geoserver.catalog.event.CatalogRemoveEvent;
+import org.geoserver.platform.resource.Files;
+
+import com.boundlessgeo.geoserver.api.controllers.ImportController;
+
+/**
+ * Listens for StoreInfo removals and deletes store files that were uploaded using the 
+ * Composer Import API or the GeoServer REST Upload API
+ */
+public class UploadDeleteCatalogListener  implements CatalogListener {
+    Catalog catalog;
+    
+    public UploadDeleteCatalogListener(Catalog catalog) {
+        this.catalog = catalog;
+        catalog.addListener(this);
+    }
+    @Override
+    public void handleAddEvent(CatalogAddEvent event) throws CatalogException { }
+
+    @Override
+    public void handleRemoveEvent(CatalogRemoveEvent event)
+            throws CatalogException {
+        CatalogInfo source = event.getSource();
+        
+        if (source instanceof StoreInfo) {
+            StoreInfo store = (StoreInfo)source;
+            try {
+                // If this store is file based, and was uploaded using the Composer API or the 
+                // REST upload API, delete the uploaded file.
+                java.io.File uploadDir = ImportController.uploadDir(catalog, store.getWorkspace(), store);
+                if (uploadDir.exists()) {
+                    Files.delete(uploadDir);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Could not delete store files for "+store.getName(), e);
+            }
+        }
+    }
+
+    @Override
+    public void handleModifyEvent(CatalogModifyEvent event)
+            throws CatalogException { }
+
+    @Override
+    public void handlePostModifyEvent(CatalogPostModifyEvent event)
+            throws CatalogException { }
+
+    @Override
+    public void reloaded() { }
+
+}

--- a/geoserver/webapp/src/main/resources/applicationContext.xml
+++ b/geoserver/webapp/src/main/resources/applicationContext.xml
@@ -41,6 +41,10 @@
       <constructor-arg ref="config" />
     </bean>
     
+    <bean class="com.boundlessgeo.geoserver.catalog.UploadDeleteCatalogListener">
+      <constructor-arg ref="catalog"/>
+    </bean>
+    
     <!-- configure thumbnail cache -->
     <bean id="config" class="com.boundlessgeo.geoserver.AppConfiguration">
       <constructor-arg ref="catalog"/>

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -64,6 +64,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -273,6 +274,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         deleteRequest.setRequestURI("/geoserver/hello");
         deleteRequest.setMethod("delete");
         storeCtrl.delete("gs", "point", true, deleteRequest);
+        assertFalse(new File(catalog.getResourceLoader().getBaseDirectory(), "uploads/gs/point/point.shp").exists());
         result = ctrl.importFile("gs", request);
         assertEquals(1, result.array("imported").size());
     }


### PR DESCRIPTION
Improvement upon #908 that uses a catalog listener to delete uploaded store files when the store is deleted.