### PR TITLE
Importer supports directories of shapefiles

### DIFF
--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -205,7 +205,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         assertNotNull(s);
         assertTrue(new File(catalog.getResourceLoader().getBaseDirectory(), "data/gs/point/point.shp").exists());
         assertTrue(new File(new URL(ResourcePool.getParams(s.getConnectionParameters(), catalog.getResourceLoader()).get("url").toString()).getFile()).exists());
-        assertEquals(new File(catalog.getResourceLoader().getBaseDirectory(), "data/gs/point/point.shp").getAbsoluteFile(),
+        assertEquals(new File(catalog.getResourceLoader().getBaseDirectory(), "data/gs/point").getAbsoluteFile(),
                 new File(new URL(ResourcePool.getParams(s.getConnectionParameters(), catalog.getResourceLoader()).get("url").toString()).getFile()).getAbsoluteFile());
 
         // ensure style in workspace
@@ -279,7 +279,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         assertNotNull(s);
         assertTrue(new File(catalog.getResourceLoader().getBaseDirectory(), "uploads/gs/point/point.shp").exists());
         assertTrue(new File(new URL(ResourcePool.getParams(s.getConnectionParameters(), catalog.getResourceLoader()).get("url").toString()).getFile()).exists());
-        assertEquals(new File(catalog.getResourceLoader().getBaseDirectory(), "uploads/gs/point/point.shp").getAbsoluteFile(),
+        assertEquals(new File(catalog.getResourceLoader().getBaseDirectory(), "uploads/gs/point").getAbsoluteFile(),
                 new File(new URL(ResourcePool.getParams(s.getConnectionParameters(), catalog.getResourceLoader()).get("url").toString()).getFile()).getAbsoluteFile());
 
         // ensure style in workspace


### PR DESCRIPTION
Fix for 
```
Exception in thread "Thread-36" java.lang.RuntimeException: DataStore file not the same as imported file
	at com.boundlessgeo.geoserver.api.controllers.ImportController.moveFile(ImportController.java:230)
	at com.boundlessgeo.geoserver.api.controllers.ImportController$TaskListener.run(ImportController.java:981)
	at java.lang.Thread.run(Thread.java:745)
```
When uploading a zip file containing multilple shapefiles