### PR TITLE
Add timeout to metadata

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/IO.java
@@ -510,6 +510,9 @@ public class IO {
         else if( r instanceof WMSLayerInfo) {
             obj.put("geometry", geometry(layer));
         }
+        if (layer.getMetadata().containsKey("timeout")) {
+            obj.put("timeout", layer.getMetadata().get("timeout"));
+        }
         return metadata(obj, layer);
     }
 

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/LayerController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/LayerController.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.net.URL;
 import java.util.Date;
 import java.util.List;
@@ -509,6 +510,8 @@ public class LayerController extends ApiController {
                     throw new BadRequestException("Unknown spatial reference identifier: " + srs);
                 }
                 resource.setSRS(srs);
+            } else if ("timeout".equals(prop)){
+                layer.getMetadata().put("timeout", (Serializable)obj.get("timeout"));
             }
         }
 

--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/MapController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/MapController.java
@@ -6,6 +6,7 @@ package com.boundlessgeo.geoserver.api.controllers;
 import static org.geoserver.catalog.Predicates.equal;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -301,6 +302,9 @@ public class MapController extends ApiController {
             }
             map.layers().clear();
             map.layers().addAll(layers);
+        }
+        if (obj.has("timeout")) {
+            map.getMetadata().put("timeout", (Serializable)obj.get("timeout"));
         }
         // update configuration history
         String user = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -647,6 +651,9 @@ public class MapController extends ApiController {
         IO.bounds(obj.putObject("projectionExtent"), CRS.getEnvelope(bounds.getCoordinateReferenceSystem()));
         obj.put("layer_count", map.getLayers().size());
 
+        if (map.getMetadata().containsKey("timeout")) {
+            obj.put("timeout", map.getMetadata().get("timeout"));
+        }
         IO.metadata(obj, map);
         if (!obj.has("modified")) {
             Resource r = dataDir().config(map);

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/LayerControllerTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/LayerControllerTest.java
@@ -168,6 +168,9 @@ public class LayerControllerTest {
                 .featureType().defaults().store("foo")
             .geoServer().build(geoServer);
 
+        LayerInfo l = gs.getCatalog().getLayerByName("foo:one");
+        l.getMetadata().put("timeout", 1000);
+        gs.getCatalog().save(l);
         MvcResult result = mvc.perform(get("/api/layers/foo/one"))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -197,6 +200,8 @@ public class LayerControllerTest {
         assertEquals(90d, obj.object("bbox").object("lonlat").doub("north"), 0.1);
         assertEquals(0d, obj.object("bbox").object("lonlat").array("center").doub(0), 0.1);
         assertEquals(0d, obj.object("bbox").object("lonlat").array("center").doub(1), 0.1);
+        
+        assertEquals(1000L, obj.get("timeout"));
 
         assertNotNull(obj.get("modified"));
         assertNotNull(obj.get("created"));
@@ -330,7 +335,7 @@ public class LayerControllerTest {
                 .featureType().defaults().store("one")
                 .geoServer().build(geoServer);
 
-        JSONObj obj = new JSONObj().put("title", "new title").put("proj", "EPSG:4326");
+        JSONObj obj = new JSONObj().put("title", "new title").put("proj", "EPSG:4326").put("timeout", 1000);
         MockHttpServletRequestBuilder req = put("/api/layers/foo/one")
             .contentType(MediaType.APPLICATION_JSON)
             .content(obj.toString());
@@ -339,6 +344,7 @@ public class LayerControllerTest {
 
         LayerInfo l = gs.getCatalog().getLayerByName("foo:one");
         verify(l, times(1)).setTitle("new title");
+        assertEquals(1000L, l.getMetadata().get("timeout"));
     }
 
     @Test

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/MapControllerTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/api/controllers/MapControllerTest.java
@@ -26,6 +26,7 @@ import com.boundlessgeo.geoserver.util.RecentObjectCache;
 
 import org.geoserver.catalog.Catalog;
 import org.geoserver.catalog.LayerGroupInfo;
+import org.geoserver.catalog.LayerInfo;
 import org.geoserver.catalog.WorkspaceInfo;
 import org.geoserver.config.GeoServer;
 import org.geoserver.security.impl.GeoServerRole;
@@ -234,6 +235,9 @@ public class MapControllerTest {
                   .layer("two").style().point().layer().featureType().defaults().store("shape")
           .geoServer().build(geoServer);
         
+        LayerGroupInfo l = gs.getCatalog().getLayerGroupByName("map");
+        l.getMetadata().put("timeout", 1000);
+        
         MvcResult result = mvc.perform(get("/api/maps/foo/map"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -267,6 +271,8 @@ public class MapControllerTest {
             }
         });
 
+        assertEquals(1000L, obj.get("timeout"));
+        
         assertNotNull(obj.get("modified"));
     }
 
@@ -313,7 +319,7 @@ public class MapControllerTest {
                         .featureType().defaults().store("store")
             .geoServer().build(geoServer);
 
-        JSONObj obj = new JSONObj().put("title", "new title").put("proj", "EPSG:4326");
+        JSONObj obj = new JSONObj().put("title", "new title").put("proj", "EPSG:4326").put("timeout", 1000);
         MockHttpServletRequestBuilder req = put("/api/maps/foo/map")
             .contentType(MediaType.APPLICATION_JSON)
             .content(obj.toString());
@@ -322,6 +328,7 @@ public class MapControllerTest {
 
         LayerGroupInfo l = gs.getCatalog().getLayerGroupByName("map");
         verify(l, times(1)).setTitle("new title");
+        assertEquals(1000L, l.getMetadata().get("timeout"));
     }
 
     @Test


### PR DESCRIPTION
Map/Layer GET/PUT now has the timeout field for storing timeout in metadata