### PR TITLE
swap to org.geotools.gt-mongodb [SUITE-1037]

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -50,6 +50,11 @@
    </dependency>
    <dependency>
      <groupId>org.geotools</groupId>
+     <artifactId>gt-mongodb</artifactId>
+     <version>${gt.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.geotools</groupId>
      <artifactId>gt-ogr-jni</artifactId>
      <version>${gt.version}</version>
    </dependency>
@@ -80,11 +85,7 @@
      <artifactId>cluster</artifactId>
      <version>${gs.version}</version>
    </dependency>
-   <dependency>
-     <groupId>org.opengeo</groupId>
-     <artifactId>gt-mongodb</artifactId>
-     <version>${gs.version}</version>
-   </dependency>
+
    <!-- GeoPackage/MBTiles -->
    <dependency>
      <groupId>org.geoserver.community</groupId>

--- a/geoserver/ext/build.xml
+++ b/geoserver/ext/build.xml
@@ -10,7 +10,7 @@
     <property name="gs-comm.ext.dir" 
         value="../externals/geoserver/src/community/target/release"/>
 
-    <property name="gs-exts.ext.list" value="cloudwatch,gsr,mapmeter,mongodb"/>
+    <property name="gs-exts.ext.list" value="cloudwatch,gsr,mapmeter"/>
     <property name="gs-exts.ext.dir" value="../externals/geoserver-exts/target/"/>
 
     <target name="build" depends="init" description="Build project">

--- a/geoserver/externals/build.xml
+++ b/geoserver/externals/build.xml
@@ -18,7 +18,7 @@
      </exec>
      <antcall target="mvn">
         <param name="dir" value="${gt.dir}"/>
-        <param name="flags" value="-DskipTests -Dall -P ogr,mbtiles,geopkg -Dpostgresql.jdbc.version=${postgresql.jdbc.version} -Dbuild.commit.id=${gt.rev} ${gt.flags}"/>
+        <param name="flags" value="-DskipTests -Dall -P ogr,mbtiles,geopkg,mongodb -Dpostgresql.jdbc.version=${postgresql.jdbc.version} -Dbuild.commit.id=${gt.rev} ${gt.flags}"/>
         <param name="goals" value="clean install"/>
      </antcall>
    </target>


### PR DESCRIPTION
Include -Pmongodb in the geotools build and update dependencies as appropriate.

After this is merged mongodb can be removed from geoserver-ext repo.