### PR TITLE
Generate Clean YSLD default styles

### DIFF
--- a/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
+++ b/geoserver/webapp/src/main/java/com/boundlessgeo/geoserver/api/controllers/ImportController.java
@@ -42,16 +42,19 @@ import org.geoserver.importer.Importer;
 import org.geoserver.importer.SpatialFile;
 import org.geoserver.importer.Table;
 import org.geoserver.importer.job.Task;
+import org.geoserver.platform.ContextLoadedEvent;
 import org.geoserver.platform.resource.Paths;
 import org.geoserver.ows.util.ResponseUtils;
 import org.geoserver.platform.resource.Resource;
 import org.geoserver.rest.util.RESTUploadExternalPathMapper;
 import org.geoserver.rest.util.RESTUploadPathMapper;
 import org.geoserver.rest.util.RESTUtils;
+import org.geoserver.ysld.YsldHandler;
 import org.geotools.data.DataAccessFactory.Param;
 import org.geotools.data.DataStoreFactorySpi;
 import org.geotools.util.logging.Logging;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -91,9 +94,12 @@ public class ImportController extends ApiController {
     private static Logger LOG = Logging.getLogger(ImportController.class);
 
     @Autowired
-    public ImportController(GeoServer geoServer, Importer importer) {
+    public ImportController(GeoServer geoServer, ApplicationContext ctx) {
         super(geoServer);
-        this.importer = importer;
+        
+        this.importer = new Importer(geoServer.getCatalog());
+        this.importer.onApplicationEvent(new ContextLoadedEvent(ctx));
+        this.importer.setStyleHandler(new YsldHandler());
         this.hasher = new Hasher(7);
     }
     
@@ -639,7 +645,8 @@ public class ImportController extends ApiController {
             }
             return result;
         }
-        result.put("importerEndpoint", ResponseUtils.baseURL(request)+"geoserver/rest/imports/"+imp.getId());
+        //Remove this while GeoServer and Composer use seperate Importer objects
+        //result.put("importerEndpoint", ResponseUtils.baseURL(request)+"geoserver/rest/imports/"+imp.getId());
         
         JSONArr tasks = result.putArray("tasks");
 

--- a/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
+++ b/geoserver/webapp/src/test/java/com/boundlessgeo/geoserver/AppIntegrationTest.java
@@ -244,9 +244,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         RESTUtils.loadMapFromGlobal().remove("root");
         assertNull(catalog.getLayerByName("gs:point"));
 
-        Importer importer =
-            GeoServerExtensions.bean(Importer.class, applicationContext);
-        ImportController ctrl = new ImportController(getGeoServer(), importer);
+        ImportController ctrl = new ImportController(getGeoServer(), applicationContext);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setContextPath("/geoserver");
@@ -261,7 +259,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         
         //Wait for the import to complete
         result = pollImport(ctrl, "gs", id, "pending", request);
-        verifyImporterEndpoint(result.str("importerEndpoint"), request);
         assertNotNull(result);
         result = ctrl.update("gs", id, getUpdateTasks(result), request);
         result = pollImport(ctrl, "gs", id, "complete", request);
@@ -308,9 +305,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         getGeoServer().save(gsInfo);
         assertNull(catalog.getLayerByName("gs:point"));
 
-        Importer importer =
-            GeoServerExtensions.bean(Importer.class, applicationContext);
-        ImportController ctrl = new ImportController(getGeoServer(), importer);
+        ImportController ctrl = new ImportController(getGeoServer(), applicationContext);
         StoreController storeCtrl = new StoreController(getGeoServer());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -339,7 +334,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         //Wait for the import to complete
         result = pollImport(ctrl, "gs", id, "pending", request);
         assertNotNull(result);
-        verifyImporterEndpoint(result.str("importerEndpoint"), request);
         result = ctrl.update("gs", id, getUpdateTasks(result), request);
         result = pollImport(ctrl, "gs", id, "complete", request);
         assertNotNull(result);
@@ -394,9 +388,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         getGeoServer().save(gsInfo);
         assertNull(catalog.getLayerByName("gs:point_space"));
 
-        Importer importer =
-            GeoServerExtensions.bean(Importer.class, applicationContext);
-        ImportController ctrl = new ImportController(getGeoServer(), importer);
+        ImportController ctrl = new ImportController(getGeoServer(), applicationContext);
         StoreController storeCtrl = new StoreController(getGeoServer());
 
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -425,7 +417,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         //Wait for the import to complete
         result = pollImport(ctrl, "gs", id, "pending", request);
         assertNotNull(result);
-        verifyImporterEndpoint(result.str("importerEndpoint"), request);
         result = ctrl.update("gs", id, getUpdateTasks(result), request);
         result = pollImport(ctrl, "gs", id, "complete", request);
         assertNotNull(result);
@@ -451,9 +442,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         Catalog catalog = getCatalog();
         assertNull(catalog.getLayerByName("gs:point"));
         
-        Importer importer =
-            GeoServerExtensions.bean(Importer.class, applicationContext);
-        ImportController ctrl = new ImportController(getGeoServer(), importer);
+        ImportController ctrl = new ImportController(getGeoServer(), applicationContext);
         
         try (H2TestData data = new H2TestData()) {
             
@@ -468,7 +457,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
             Long id = Long.parseLong(result.str("id"));
             result = pollImport(ctrl, "gs", id, "pending", request);
             assertNotNull(result);
-            verifyImporterEndpoint(result.str("importerEndpoint"), request);
             assertTrue(result.integer("tasksTotal") > 0);
             List<String> names = Arrays.asList(new String[]{"ft1","ft2","ft3"});
             JSONArr tasks = new JSONArr();
@@ -478,7 +466,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
                     assertEquals("table", o.get("type"));
                 }
             }
-            assertTrue(tasks.size() > 0);
             JSONObj response = new JSONObj();
             response.put("tasks", tasks);
             
@@ -541,9 +528,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         StoreInfo targetStore = catalog.getStoreByName("sf", "sf", StoreInfo.class);
         assertNotNull(targetStore);
         
-        Importer importer =
-                GeoServerExtensions.bean(Importer.class, applicationContext);
-        ImportController ctrl = new ImportController(getGeoServer(), importer);
+        ImportController ctrl = new ImportController(getGeoServer(), applicationContext);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setContextPath("/geoserver");
@@ -559,7 +544,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         //Wait for the import to complete
         result = pollImport(ctrl, "gs", id, "pending", request);
         assertNotNull(result);
-        verifyImporterEndpoint(result.str("importerEndpoint"), request);
         result = ctrl.update("gs", id, getUpdateTasks(result), request);
         result = pollImport(ctrl, "gs", id, "complete", request);
         assertNotNull(result);
@@ -591,12 +575,6 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         return response.put("tasks", tasks);
     }
     
-    private void verifyImporterEndpoint(String url, HttpServletRequest request) throws Exception {
-        String baseURL = ResponseUtils.baseURL(request)+"geoserver/";
-        String relativeURL = url.substring(baseURL.length());
-        com.mockrunner.mock.web.MockHttpServletResponse res = getAsServletResponse(relativeURL);
-        assertEquals("application/json", res.getContentType());
-    }
     private JSONObj pollImport(ImportController ctrl, String ws, Long id, String state, HttpServletRequest request) {
         int attempts = 100;
         int interval = 10;
@@ -622,9 +600,7 @@ public class AppIntegrationTest extends GeoServerSystemTestSupport {
         StoreInfo targetStore = catalog.getStoreByName("sf", "sf", StoreInfo.class);
         assertNotNull(targetStore);
         
-        Importer importer =
-                GeoServerExtensions.bean(Importer.class, applicationContext);
-        ImportController ctrl = new ImportController(getGeoServer(), importer);
+        ImportController ctrl = new ImportController(getGeoServer(), applicationContext);
 
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setContextPath("/geoserver");


### PR DESCRIPTION
Add support for default YSLD styles to composer, rather than having a bunch of orphanded SLD files floating around.

Seperate Importer object for Composer and GeoServer, with composer always using YSLD and GeoServer always using SLD. Note that this means that composer imports will not show up in the list of imports in the geoserver UI and REST API (don't know if this is a good thing or a bad thing...).

This is a temporary measure until a proper configuration setting is added to the GeoServer UI.