### PR TITLE
Fix Bing Maps failure more gracefully (SUITE-1613)

### DIFF
--- a/geoexplorer/app/templates/composer.html
+++ b/geoexplorer/app/templates/composer.html
@@ -53,6 +53,7 @@
                 },
                 bing: {
                     ptype: "gxp_bingsource"
+                    /* ,apiKey: [insert your api key here] */
                 },
                 mapbox: {
                     ptype: "gxp_mapboxsource"


### PR DESCRIPTION
Google Maps fix was already in master, so this just has the updates for the Bing Maps fixes (comment in composer template, and more graceful handling of no api Key in gxp BingSource).