### PR TITLE
Move care and feeding docs out of installation section [SUITE-1846]

### DIFF
--- a/docs/usermanual/source/sysadmin/mac/index.rst
+++ b/docs/usermanual/source/sysadmin/mac/index.rst
@@ -1,4 +1,47 @@
 .. _sysadmin.mac:
 
-Windows Suite Administration
-============================
+Mac Suite Administration
+========================
+
+This document contains information about various tasks specific to OpenGeo Suite for Mac OS X. 
+
+Starting and stopping Boundless services
+----------------------------------------
+
+Service port configuration
+--------------------------
+
+The Tomcat and PostgreSQL services run on ports **8080** and **5432** respectively. These ports can often conflict with existing services on the system, in which case the ports must be changed.
+
+Changing the Tomcat port
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Changing the PostgreSQL port
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the PostgreSQL port:
+
+#. Edit the following file::
+
+     ~/Library/Application\ Support/PostGIS/var/postgresql.conf
+
+#. Search or the ``port`` property (around line 63), uncomment it and change its value from 5432 to a number that does not conflict with any existing services on the machine.
+
+GeoServer Data Directory
+------------------------
+
+The **GeoServer Data Directory** is the location on the file system where GeoServer stores all of its configuration, and (optionally) file-based data. By default, this directory is located at :file:`~/Library/Application Support/GeoServer`.
+
+To point GeoServer to an alternate location:
+
+#. TBD
+
+#. Close and relaunch ``Tomcat.app``.
+
+PostgreSQL Configuration
+------------------------
+
+PostgreSQL configuration is controlled within the ``postgresql.conf`` file. This file is located here::
+
+  ~/Library/Application\ Support/PostGIS/var/postgresql.conf
+

--- a/docs/usermanual/source/sysadmin/redhat/index.rst
+++ b/docs/usermanual/source/sysadmin/redhat/index.rst
@@ -1,4 +1,262 @@
 .. _sysadmin.redhat:
 
 RedHat Suite Administration
-============================
+===========================
+
+
+This document contains information about various tasks specific to Boundless Suite for Ubuntu Linux. For more details, please see the :ref:`sysadmin` section.
+
+Starting and stopping Boundless Suite services
+----------------------------------------------
+
+Boundless Suite is comprised of two main services:
+
+#. The `Tomcat <http://tomcat.apache.org/>`_ web server that contains all the Boundless web applications such as GeoServer, GeoWebCache, and GeoExplorer. 
+
+#. The `PostgreSQL <http://www.postgresql.org/>`_ database server with the PostGIS spatial extensions.
+
+.. note:: The Tomcat service used by Boundless Suite is pulled in from standard repository sources, and is not specific to Boundless Suite.
+
+Controlling the Tomcat service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To start/stop/restart the Tomcat service:
+
+  .. code-block:: bash
+ 
+     service tomcat start|stop|restart
+
+.. note:: Depending on the distribution and version the service name may be one of "tomcat", "tomcat5", or "tomcat6". Use the :command:`service` command to determine which one is installed:
+
+  .. code-block:: bash
+
+     service --status-all | grep tomcat
+
+Controlling the PostgreSQL service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before PostgreSQL service can be started it must first be initialized:
+
+  .. code-block:: bash
+
+     service postgresql-9.3 initdb
+
+To start/stop/restart the PostgreSQL service:
+
+  .. code-block:: bash
+ 
+     service postgresql-9.3 start|stop|restart
+
+Service port configuration
+--------------------------
+
+The Tomcat and PostgreSQL services run on ports **8080** and **5432** respectively. These ports can often conflict with existing services on the systemk, in which case the ports must be changed. 
+
+Changing the Tomcat port
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the Tomcat port:
+
+#. Edit the file :file:`/etc/tomcat/server.xml`. 
+
+   .. note:: Depending on the distribution and version replace "tomcat" with "tomcat5" or "tomact6" accordingly. Use the :command:`service` command to determine which one is installed:
+
+      .. code-block:: bash
+
+         service --status-all | grep tomcat
+
+#. Search for "8080" (around line 75) and change the ``port`` attribute to the desired value.
+
+#. Restart tomcat. 
+
+   .. code-block:: bash
+
+        service tomcat restart
+
+Changing the PostgreSQL port
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the PostgreSQL port:
+
+#. Edit the file :file:`/var/lib/pgsql/9.3/data/postgresql.conf`.
+
+#. Search or the ``port`` property (around line 63), uncomment and change it to the desired value.
+
+#. Restart PostgreSQL.
+
+   .. code-block:: bash
+
+       service postgresql-9.3 restart
+
+Working with Tomcat
+-------------------
+
+Changing the Tomcat Java
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you wish to use the Oracle Java 7 JRE (rather than the OpenJDK 7 installed by default):
+
+#. Download and install Oracle Java 7 JRE.
+
+#. Open :file:`/etc/sysconfig/tomcat` and update the ``JAVA_HOME`` environment variable.
+
+   .. note:: Make sure the line is uncommented (does not start with ``#``).
+
+#. Save and close the file.
+
+#. Restart Tomcat.
+
+Using Boundless Suite with custom Tomcat
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Boundless Suite packages can be used to manage the contents :file:`/usr/share/boundless` components while making use of your own Tomcat application server.
+
+#. Install Boundless Suite.
+
+#. Stop your Tomcat service.
+
+#. Navigate to :file:`/etc/tomcat/Catalina/localhost/`.
+
+#. Create the :file:`geoserver.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="geoserver"
+               docBase="/usr/share/boundless/geoserver"
+               path="/geoserver"/>
+
+#. Create the :file:`geowebcache.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="geowebcache"
+               docBase="/usr/share/boundless/geowebcache"
+               path="/geowebcache"/>
+
+#. Create the :file:`dashboard.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="dashboard"
+               docBase="/usr/share/boundless/dashboard"
+               path="/dashboard"/>
+
+#. Create the :file:`geoexplorer.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="geoexplorer"
+               docBase="/usr/share/boundless/geoexplorer"
+               path="/geoexplorer"/>
+
+#. Create the :file:`docs.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="docs"
+               docBase="/usr/share/boundless/docs"
+               path="/docs"/>
+
+#. Restart Tomcat.
+
+Adding other system parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can add other system or application-specific parameters that will be picked up upon restart.
+
+#. Open :file:`/etc/sysconfig/tomcat` in a text editor.
+
+#. Add the desired parameters to the bottom of the file.
+
+#. Save and close the file.
+
+#. Restart Tomcat.
+
+.. _intro.installation.redhat.postinstall.geoserver:
+
+Working with GeoServer
+----------------------
+
+GeoServer Data Directory
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The **GeoServer Data Directory** is the location on the file system where GeoServer stores all of its configuration, and (optionally) file-based data. By default, this directory is located at: :file:`/var/lib/boundless/geoserver`. 
+
+To point GeoServer to an alternate location:
+
+#. Edit the file :file:`geoserver/WEB-INF/web.xml`.
+
+#. Search for ``GEOSERVER_DATA_DIR`` section, uncomment, and change its value accordingly.
+   
+   .. code-block:: xml
+      
+       <context-param>
+          <param-name>GEOSERVER_DATA_DIR</param-name>
+           <param-value>/path/to/new/data_dir</param-value>
+       </context-param> 
+
+#. Restart Tomcat.
+
+Enabling spatial reference systems with Imperial units
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A fix is available for spatial reference systems measured in Imperial units (feet). This setting is recommended for all users, and strongly recommended for those working with **US State Plane** projections measured in feet.
+
+To enable this fix:
+
+#. Add the following parameter to :file:`/etc/sysconfig/tomcat`:
+   
+   .. code-block:: bash
+      
+      -Dorg.geotoools.render.lite.scale.unitCompensation=true
+
+#. Restart Tomcat.
+
+Update GeoJSON output
+^^^^^^^^^^^^^^^^^^^^^
+ 
+GeoServer GeoJSON output is now provided in x/y/z order as required by the specification. In addition, the ``crs``  output has changed to support full URN representation of spatial reference systems:
+   
+   .. code-block:: json
+
+      "crs": {
+         "type": "name",
+         "properties": {
+            "name": "urn:ogc:def:crs:EPSG::4326"
+         }
+      }
+
+.. note::
+
+   Previously, the output was:
+
+      .. code-block:: json
+   
+         "crs": {
+            "type": "EPSG",
+            "properties": {
+               "code": "4326"
+            }
+         }
+   
+To restore the previous ``crs`` representation for compatibility reasons (especially when working with OpenLayers 3):
+
+#. Add the following context parameter to  :file:`geoserver/WEB-INF/web.xml`:
+
+   .. code-block:: xml
+      
+       <context-param>
+           <param-name>GEOSERVER_GEOJSON_LEGACY_CRS</param-name>
+           <param-value>true</param-value>
+       </context-param>
+
+#. Restart Tomcat.
+
+.. _intro.installation.redhat.postinstall.pgconfig:
+
+PostgreSQL configuration
+------------------------
+
+PostgreSQL configuration is controlled within the ``postgresql.conf`` file. This file is located at :file:`/etc/postgresql/9.3/main/postgresql.conf`. 
+
+You will want to ensure that you can connect to the database. Please see the section on :ref:`dataadmin.pgGettingStarted.firstconnect` to set this up.

--- a/docs/usermanual/source/sysadmin/redhat/index.rst
+++ b/docs/usermanual/source/sysadmin/redhat/index.rst
@@ -24,9 +24,9 @@ To start/stop/restart the Tomcat service:
 
   .. code-block:: bash
  
-     service tomcat start|stop|restart
+     service tomcat8 start|stop|restart
 
-.. note:: Depending on the distribution and version the service name may be one of "tomcat", "tomcat5", or "tomcat6". Use the :command:`service` command to determine which one is installed:
+.. note:: Depending on the distribution and version the service name may be one of "tomcat", "tomcat8", or "tomcat9". Use the :command:`service` command to determine which one is installed:
 
   .. code-block:: bash
 
@@ -57,21 +57,15 @@ Changing the Tomcat port
 
 To change the Tomcat port:
 
-#. Edit the file :file:`/etc/tomcat/server.xml`. 
+#. Edit the file :file:`/etc/tomcat8/server.xml`. 
 
-   .. note:: Depending on the distribution and version replace "tomcat" with "tomcat5" or "tomact6" accordingly. Use the :command:`service` command to determine which one is installed:
-
-      .. code-block:: bash
-
-         service --status-all | grep tomcat
-
-#. Search for "8080" (around line 75) and change the ``port`` attribute to the desired value.
+#. Search for "8080" and change the ``port`` attribute to the desired value.
 
 #. Restart tomcat. 
 
    .. code-block:: bash
 
-        service tomcat restart
+        service tomcat8 restart
 
 Changing the PostgreSQL port
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -98,7 +92,7 @@ If you wish to use the Oracle Java 7 JRE (rather than the OpenJDK 7 installed by
 
 #. Download and install Oracle Java 7 JRE.
 
-#. Open :file:`/etc/sysconfig/tomcat` and update the ``JAVA_HOME`` environment variable.
+#. Open :file:`/etc/sysconfig/tomcat8` and update the ``JAVA_HOME`` environment variable.
 
    .. note:: Make sure the line is uncommented (does not start with ``#``).
 
@@ -106,73 +100,38 @@ If you wish to use the Oracle Java 7 JRE (rather than the OpenJDK 7 installed by
 
 #. Restart Tomcat.
 
-Using Boundless Suite with custom Tomcat
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   .. code-block:: bash
 
-Boundless Suite packages can be used to manage the contents :file:`/usr/share/boundless` components while making use of your own Tomcat application server.
-
-#. Install Boundless Suite.
-
-#. Stop your Tomcat service.
-
-#. Navigate to :file:`/etc/tomcat/Catalina/localhost/`.
-
-#. Create the :file:`geoserver.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="geoserver"
-               docBase="/usr/share/boundless/geoserver"
-               path="/geoserver"/>
-
-#. Create the :file:`geowebcache.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="geowebcache"
-               docBase="/usr/share/boundless/geowebcache"
-               path="/geowebcache"/>
-
-#. Create the :file:`dashboard.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="dashboard"
-               docBase="/usr/share/boundless/dashboard"
-               path="/dashboard"/>
-
-#. Create the :file:`geoexplorer.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="geoexplorer"
-               docBase="/usr/share/boundless/geoexplorer"
-               path="/geoexplorer"/>
-
-#. Create the :file:`docs.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="docs"
-               docBase="/usr/share/boundless/docs"
-               path="/docs"/>
-
-#. Restart Tomcat.
+        service tomcat8 restart
 
 Adding other system parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can add other system or application-specific parameters that will be picked up upon restart.
 
-#. Open :file:`/etc/sysconfig/tomcat` in a text editor.
+#. The :file:`/etc/sysconfig/tomcat8` is responsible for the tomcat service.
 
-#. Add the desired parameters to the bottom of the file.
-
-#. Save and close the file.
+   * To provide an environmental variable open :file:`/etc/sysconfig/tomcat8` in a text editor, add the desired parameters to the bottom of the file.
+     
+     Environmental variables defined at the end of :file:`/etc/tomcat8/tomcat8`::
+        
+      GDAL_DATA=/usr/share/gdal
+      GEOSERVER_DATA_DIR=/opt/boundless/suite/geoserver-data/
+      GEOWEBCACHE_CACHE_DIR=/opt/boundless/suite/geowebcache-data/
+   
+   * System properties are read in from the files in :file:`/etc/tomcat8/suite-opts/` (to make these settings easier to manage).
+     
+     Example :file:`/etc/tomcat8/suite-opts/memory`::
+         
+         -Xmx2G
 
 #. Restart Tomcat.
 
 .. _intro.installation.redhat.postinstall.geoserver:
+
+   .. code-block:: bash
+
+        service tomcat8 restart
 
 Working with GeoServer
 ----------------------
@@ -182,9 +141,22 @@ GeoServer Data Directory
 
 The **GeoServer Data Directory** is the location on the file system where GeoServer stores all of its configuration, and (optionally) file-based data. By default, this directory is located at: :file:`/var/lib/boundless/geoserver`. 
 
-To point GeoServer to an alternate location:
+To point GeoServer to an alternate location using an environment variable:
 
-#. Edit the file :file:`geoserver/WEB-INF/web.xml`.
+   * Edit :file:`/etc/sysconfig/tomcat8` in a text editor, add the desired parameters to the bottom of the file.
+     
+     Environmental variables defined at the end of :file:`/etc/tomcat8/tomcat8`::
+        
+      GDAL_DATA=/usr/share/gdal
+      GEOSERVER_DATA_DIR=/opt/boundless/suite/geoserver-data/
+      GEOWEBCACHE_CACHE_DIR=/opt/boundless/suite/geowebcache-data/
+
+
+To point GeoServer to an alternate location using a servlet parameter:
+
+#. This approach can be used when deploying several GeoServer's on the same Tomcat Service.
+
+#. Navigate to :file:`/usr/share/tomcat8/webapps` and edit the file :file:`geoserver/WEB-INF/web.xml`.
 
 #. Search for ``GEOSERVER_DATA_DIR`` section, uncomment, and change its value accordingly.
    
@@ -204,13 +176,17 @@ A fix is available for spatial reference systems measured in Imperial units (fee
 
 To enable this fix:
 
-#. Add the following parameter to :file:`/etc/sysconfig/tomcat`:
-   
-   .. code-block:: bash
+#. Add a system properties definition to the :file:`/etc/tomcat8/suite-opts/` folder.
+
+#. Create the file :file:`/etc/tomcat8/suite-opts/units`::
       
       -Dorg.geotoools.render.lite.scale.unitCompensation=true
 
 #. Restart Tomcat.
+
+   .. code-block:: bash
+
+        service tomcat8 restart
 
 Update GeoJSON output
 ^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +217,9 @@ GeoServer GeoJSON output is now provided in x/y/z order as required by the speci
    
 To restore the previous ``crs`` representation for compatibility reasons (especially when working with OpenLayers 3):
 
-#. Add the following context parameter to  :file:`geoserver/WEB-INF/web.xml`:
+#. Navigate to :file:`/usr/share/tomcat8/webapps` and edit the file :file:`geoserver/WEB-INF/web.xml`.
+
+#. Add the following context parameter to  :file:`web.xml`:
 
    .. code-block:: xml
       
@@ -252,6 +230,10 @@ To restore the previous ``crs`` representation for compatibility reasons (especi
 
 #. Restart Tomcat.
 
+   .. code-block:: bash
+
+        service tomcat8 restart
+        
 .. _intro.installation.redhat.postinstall.pgconfig:
 
 PostgreSQL configuration

--- a/docs/usermanual/source/sysadmin/redhat/index.rst
+++ b/docs/usermanual/source/sysadmin/redhat/index.rst
@@ -143,20 +143,29 @@ The **GeoServer Data Directory** is the location on the file system where GeoSer
 
 To point GeoServer to an alternate location using an environment variable:
 
-   * Edit :file:`/etc/sysconfig/tomcat8` in a text editor, add the desired parameters to the bottom of the file.
+#. Edit :file:`/etc/sysconfig/tomcat8` in a text editor, add the desired parameters to the bottom of the file.
      
-     Environmental variables defined at the end of :file:`/etc/tomcat8/tomcat8`::
+   Environmental variables are defined at the end of :file:`/etc/tomcat8/tomcat8`::
         
       GDAL_DATA=/usr/share/gdal
       GEOSERVER_DATA_DIR=/opt/boundless/suite/geoserver-data/
       GEOWEBCACHE_CACHE_DIR=/opt/boundless/suite/geowebcache-data/
 
+#. Restart Tomcat
+
+To point GeoServer at a data directory using a system property:
+
+#. Create :file:`/etc/tomcat8/suite-opts/data`::
+         
+         -DGEOSERVER_DATA_DIR=/opt/boundless/suite/geoserver-data/
+   
+#. Restart Tomcat
 
 To point GeoServer to an alternate location using a servlet parameter:
 
 #. This approach can be used when deploying several GeoServer's on the same Tomcat Service.
 
-#. Navigate to :file:`/usr/share/tomcat8/webapps` and edit the file :file:`geoserver/WEB-INF/web.xml`.
+   Navigate to :file:`/usr/share/tomcat8/webapps` and edit the file :file:`geoserver/WEB-INF/web.xml`.
 
 #. Search for ``GEOSERVER_DATA_DIR`` section, uncomment, and change its value accordingly.
    

--- a/docs/usermanual/source/sysadmin/ubuntu/index.rst
+++ b/docs/usermanual/source/sysadmin/ubuntu/index.rst
@@ -2,3 +2,246 @@
 
 Ubuntu Suite Administration
 ============================
+
+This document contains information about various tasks specific to Boundless Suite for Ubuntu Linux. For more details, please see the :ref:`sysadmin` section.
+
+.. note:: This section is also applicable to those running a Boundless Suite in a Virtual Machine.
+
+Starting and stopping Boundless Suite services
+----------------------------------------------
+
+Boundless Suite is comprised of two main services:
+
+#. The `Tomcat <http://tomcat.apache.org/>`_ web server that contains all the web applications such as GeoServer, GeoWebCache, and GeoExplorer. 
+
+#. The `PostgreSQL <http://www.postgresql.org/>`_ database server with the PostGIS spatial extensions.
+
+.. note:: The Tomcat service used by Boundless Suite is pulled in from standard repository sources, and is not specific to Boundless Suite.
+
+Controlling the Tomcat service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To start/stop/restart the Tomcat service:
+
+  .. code-block:: bash
+ 
+     sudo service tomcat8 start|stop|restart
+
+Other options in addition to the above are ``try-restart``, ``force-restart``, and ``status``.
+
+Controlling the PostgreSQL service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To start/stop/restart the PostgreSQL service:
+
+  .. code-block:: bash
+ 
+     sudo service postgresql start|stop|restart
+
+Other options in addition to the above are ``reload``, ``force-reload``, and ``status``.
+
+  .. note:: If you have multiple versions of PostgresSQL installed you can specify which version to control with a third argument. For example:
+
+     .. code-block:: bash
+
+         sudo service postgresql start 9.3 
+
+Service port configuration
+--------------------------
+
+The Tomcat and PostgreSQL services run on ports **8080** and **5432** respectively. These ports can often conflict with existing services on the system, in which case the ports must be changed. 
+
+Changing the Tomcat port
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the Tomcat port:
+
+#. Edit the file :file:`/etc/tomcat8/server.xml`. 
+
+#. Search for ``8080`` (around line 71) and change the ``port`` attribute to the desired value.
+
+#. Restart Tomcat.
+
+Changing the PostgreSQL port
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the PostgreSQL port:
+
+#. Edit the file :file:`/etc/postgresql/9.3/main/postgresql.conf`.
+
+#. Search or the ``port`` property (around line 63) and change it to the desired value.
+
+#. Restart PostgreSQL.
+
+Working with Tomcat
+-------------------
+
+Changing the Tomcat Java
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you wish to use the Oracle Java 8 JRE (rather than the OpenJDK 8 installed by default):
+
+#. Download and install Oracle Java 8 JRE.
+
+#. Open :file:`/etc/default/tomcat8` and update the ``JAVA_HOME`` environment variable.
+
+   .. note:: Make sure the line is uncommented (does not start with ``#``).
+
+#. Save and close the file.
+
+#. Restart Tomcat.
+
+Using Boundless Suite with custom Tomcat
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Boundless Suite packages can be used to manage the contents :file:`/usr/share/opengeo` components while making use of your own Tomcat application server.
+
+#. Install Boundless Suite.
+
+#. Stop your Tomcat service.
+
+#. Navigate to :file:`/etc/tomcat8/Catalina/localhost/`.
+
+#. Create the :file:`geoserver.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="geoserver"
+               docBase="/usr/share/opengeo/geoserver"
+               path="/geoserver"/>
+
+#. Create the :file:`geowebcache.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="geowebcache"
+               docBase="/usr/share/opengeo/geowebcache"
+               path="/geowebcache"/>
+
+#. Create the :file:`dashboard.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="dashboard"
+               docBase="/usr/share/opengeo/dashboard"
+               path="/dashboard"/>
+
+#. Create the :file:`geoexplorer.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="geoexplorer"
+               docBase="/usr/share/opengeo/geoexplorer"
+               path="/geoexplorer"/>
+
+#. Create the :file:`docs.xml` with the following content:
+   
+   .. code-block:: xml
+   
+      <Context displayName="docs"
+               docBase="/usr/share/opengeo/docs"
+               path="/docs"/>
+
+#. Restart Tomcat.
+
+Adding other system parameters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can add other system or application-specific parameters that will be picked up upon restart.
+
+#. Open :file:`/etc/default/tomcat8` in a text editor.
+
+#. Add the desired parameters to the bottom of the file.
+
+#. Save and close the file.
+
+#. Restart Tomcat.
+
+.. _intro.installation.ubuntu.postinstall.geoserver:
+
+Working with GeoServer
+----------------------
+
+GeoServer Data Directory
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The **GeoServer Data Directory** is the location on the file system where GeoServer stores all of its configuration, and (optionally) file-based data. By default, this directory is located at: :file:`/var/lib/opengeo/geoserver`. 
+
+To point GeoServer to an alternate location:
+
+#. Edit the file :file:`geoserver/WEB-INF/web.xml`.
+
+#. Search for ``GEOSERVER_DATA_DIR`` section, uncomment, and change its value accordingly.
+   
+   .. code-block:: xml
+      
+       <context-param>
+          <param-name>GEOSERVER_DATA_DIR</param-name>
+           <param-value>/path/to/new/data_dir</param-value>
+       </context-param> 
+
+#. Restart Tomcat.
+
+Enabling spatial reference systems with Imperial units
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A fix is available for spatial reference systems measured in Imperial units (feet). This setting is recommended for all users, and strongly recommended for those working with **US State Plane** projections measured in feet.
+
+To enable this fix:
+
+#. Add the following parameter to :file:`/etc/default/tomcat7`:
+   
+   .. code-block:: bash
+      
+      -Dorg.geotoools.render.lite.scale.unitCompensation=true
+
+#. Restart Tomcat.
+
+Update GeoJSON output
+^^^^^^^^^^^^^^^^^^^^^
+ 
+GeoServer GeoJSON output is now provided in x/y/z order as required by the specification. In addition, the ``crs``  output has changed to support full URN representation of spatial reference systems:
+   
+   .. code-block:: json
+
+      "crs": {
+         "type": "name",
+         "properties": {
+            "name": "urn:ogc:def:crs:EPSG::4326"
+         }
+      }
+
+.. note::
+
+   Previously, the output was:
+
+      .. code-block:: json
+   
+         "crs": {
+            "type": "EPSG",
+            "properties": {
+               "code": "4326"
+            }
+         }
+   
+To restore the previous ``crs`` representation for compatibility reasons (especially when working with OpenLayers 3):
+
+#. Add the following context parameter to  :file:`/usr/share/opengeo/geoserver/WEB-INF/web.xml`:
+
+   .. code-block:: xml
+      
+       <context-param>
+           <param-name>GEOSERVER_GEOJSON_LEGACY_CRS</param-name>
+           <param-value>true</param-value>
+       </context-param>
+
+#. Restart Tomcat.
+
+.. _intro.installation.ubuntu.postinstall.pgconfig:
+
+PostgreSQL configuration
+------------------------
+
+PostgreSQL configuration is controlled within the ``postgresql.conf`` file. This file is located at :file:`/etc/postgresql/9.3/main/postgresql.conf`. 
+
+You will want to ensure that you can connect to the database. Please see the section on :ref:`dataadmin.pgGettingStarted.firstconnect` to set this up.

--- a/docs/usermanual/source/sysadmin/ubuntu/index.rst
+++ b/docs/usermanual/source/sysadmin/ubuntu/index.rst
@@ -91,69 +91,26 @@ If you wish to use the Oracle Java 8 JRE (rather than the OpenJDK 8 installed by
 
 #. Restart Tomcat.
 
-Using Boundless Suite with custom Tomcat
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Boundless Suite packages can be used to manage the contents :file:`/usr/share/opengeo` components while making use of your own Tomcat application server.
-
-#. Install Boundless Suite.
-
-#. Stop your Tomcat service.
-
-#. Navigate to :file:`/etc/tomcat8/Catalina/localhost/`.
-
-#. Create the :file:`geoserver.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="geoserver"
-               docBase="/usr/share/opengeo/geoserver"
-               path="/geoserver"/>
-
-#. Create the :file:`geowebcache.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="geowebcache"
-               docBase="/usr/share/opengeo/geowebcache"
-               path="/geowebcache"/>
-
-#. Create the :file:`dashboard.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="dashboard"
-               docBase="/usr/share/opengeo/dashboard"
-               path="/dashboard"/>
-
-#. Create the :file:`geoexplorer.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="geoexplorer"
-               docBase="/usr/share/opengeo/geoexplorer"
-               path="/geoexplorer"/>
-
-#. Create the :file:`docs.xml` with the following content:
-   
-   .. code-block:: xml
-   
-      <Context displayName="docs"
-               docBase="/usr/share/opengeo/docs"
-               path="/docs"/>
-
-#. Restart Tomcat.
-
 Adding other system parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can add other system or application-specific parameters that will be picked up upon restart.
 
-#. Open :file:`/etc/default/tomcat8` in a text editor.
+#. The :file:`/etc/sysconfig/tomcat8` is responsible for the tomcat service.
 
-#. Add the desired parameters to the bottom of the file.
-
-#. Save and close the file.
+   * To provide an environmental variable open :file:`/etc/sysconfig/tomcat8` in a text editor, add the desired parameters to the bottom of the file.
+     
+     Environmental variables defined at the end of :file:`/etc/tomcat8/tomcat8`::
+        
+      GDAL_DATA=/usr/share/gdal
+      GEOSERVER_DATA_DIR=/opt/boundless/suite/geoserver-data/
+      GEOWEBCACHE_CACHE_DIR=/opt/boundless/suite/geowebcache-data/
+   
+   * System properties are read in from the files in :file:`/etc/tomcat8/suite-opts/` (to make these settings easier to manage).
+     
+     Example :file:`/etc/tomcat8/suite-opts/memory`::
+         
+         -Xmx2G
 
 #. Restart Tomcat.
 
@@ -169,15 +126,15 @@ The **GeoServer Data Directory** is the location on the file system where GeoSer
 
 To point GeoServer to an alternate location:
 
-#. Edit the file :file:`geoserver/WEB-INF/web.xml`.
+#. Edit the file :file:`/etc/tomcat8/Catalina/localhost/geoserver.xml`.
 
-#. Search for ``GEOSERVER_DATA_DIR`` section, uncomment, and change its value accordingly.
+   Define ``GEOSERVER_DATA_DIR`` with an appropriate value accordingly.
    
    .. code-block:: xml
       
        <context-param>
           <param-name>GEOSERVER_DATA_DIR</param-name>
-           <param-value>/path/to/new/data_dir</param-value>
+           <param-value>/var/opt/boundless/geoserver/data/</param-value>
        </context-param> 
 
 #. Restart Tomcat.
@@ -189,7 +146,7 @@ A fix is available for spatial reference systems measured in Imperial units (fee
 
 To enable this fix:
 
-#. Add the following parameter to :file:`/etc/default/tomcat7`:
+#. Add the following parameter to :file:`/etc/tomcat8/suite-opts/scale`
    
    .. code-block:: bash
       
@@ -226,7 +183,7 @@ GeoServer GeoJSON output is now provided in x/y/z order as required by the speci
    
 To restore the previous ``crs`` representation for compatibility reasons (especially when working with OpenLayers 3):
 
-#. Add the following context parameter to  :file:`/usr/share/opengeo/geoserver/WEB-INF/web.xml`:
+#. Add a context parameter to :file:`/etc/tomcat8/Catalina/localhost/geoserver.xml`:
 
    .. code-block:: xml
       

--- a/docs/usermanual/source/sysadmin/windows/index.rst
+++ b/docs/usermanual/source/sysadmin/windows/index.rst
@@ -2,3 +2,72 @@
 
 Windows Suite Administration
 ============================
+
+
+This document contains information about various tasks specific to Boundless Suite for Windows. 
+
+.. |postgresql.conf| replace:: :file:`C:\\ProgramData\\Boundless\\OpenGeo\\pgsql\\9.3\\postgresql.conf`
+
+.. todo:: Might want to make the PG version a global var.
+
+Starting and stopping Boundless services
+----------------------------------------
+
+Boundless Suite is comprised of two services:
+
+#. **Tomcat** - The Tomcat web server that contains all the Boundless web applications such as GeoServer, GeoWebCache, and GeoExplorer.
+   
+   The service can be started / stopped from the :command:`Tomcat Manger` application.
+
+#. **Boundless PostgreSQL** - The `PostgreSQL <http://www.postgresql.org/>`_ database server with the PostGIS spatial extensions. 
+
+   The services can be started and stopped directly from the Start Menu by navigating to :menuselection:`All Programs --> Boundless Suite` and using the :guilabel:`Start` and :guilabel:`Stop` short cuts. They must be run with Adminstrator rights.
+
+
+Services can also be controlled from the Windows :guilabel:`Services` dialog available by navigating to :menuselection:`Administrative Tools --> Services` from the Windows :guilabel:`Control Panel`.
+
+Service port configuration
+--------------------------
+
+The Tomcat and PostgreSQL services run on ports **8080** and **5432** respectively. These ports can often conflict with existing services on the system, in which case the ports must be changed. 
+
+Changing the Tomcat port
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TBD
+
+Changing the PostgreSQL port
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To change the PostgreSQL port:
+
+#. Open the file :file:`C:\\Program Files\\Boundless\\OpenGeo\\pgsql\\postgresql.conf` in a text editor such as Notepad.
+
+#. Search or the ``port`` property (around line 63), uncomment it and change its value from ``5432`` to a number that does not conflict with any existing services on the machine.
+
+#. Restart OpenGeo PostgreSQL service.
+
+.. _intro.installation.windows.postinstall.datadir:
+
+GeoServer Data Directory
+------------------------
+
+The **GeoServer Data Directory** is the location on the file system where GeoServer stores all of its configuration, and (optionally) file-based data.
+
+By default, this directory is located at :file:`C:\\ProgramData\\Boundless\\geoserver\\data`.
+
+To point GeoServer to an alternate location:
+
+#. Change the Tomcat Java Options to point at the new location
+
+#. Restart the Tomcat service
+
+PostgreSQL Configuration
+------------------------
+
+PostgreSQL configuration is controlled within the ``postgresql.conf`` file. This
+file is located at:
+
+|postgresql.conf|
+
+.. note:: The :file:`ProgramData` directory is hidden, so it will not display in standard directory listings.


### PR DESCRIPTION
In the installation sections, there are pages on "working with" the install. It makes more sense to move it out of there and into the sysadmin section.