### PR TITLE
Update data_dir

### DIFF
--- a/geoserver/data_dir/security/auth/default/config.xml
+++ b/geoserver/data_dir/security/auth/default/config.xml
@@ -1,0 +1,6 @@
+<usernamePassword>
+  <id>52857278:13c7ffd66a8:-7ff0</id>
+  <name>default</name>
+  <className>org.geoserver.security.auth.UsernamePasswordAuthenticationProvider</className>
+  <userGroupServiceName>default</userGroupServiceName>
+</usernamePassword>

--- a/geoserver/data_dir/security/config.xml
+++ b/geoserver/data_dir/security/config.xml
@@ -1,0 +1,36 @@
+<security>
+  <roleServiceName>default</roleServiceName>
+  <authProviderNames>
+    <string>default</string>
+  </authProviderNames>
+  <configPasswordEncrypterName>pbePasswordEncoder</configPasswordEncrypterName>
+  <encryptingUrlParams>false</encryptingUrlParams>
+  <filterChain>
+    <filters name="web" class="org.geoserver.security.HtmlLoginFilterChain" interceptorName="interceptor" exceptionTranslationName="exception" path="/web/**,/gwc/rest/web/**,/" disabled="false" allowSessionCreation="true" ssl="false" matchHTTPMethod="false">
+      <filter>rememberme</filter>
+      <filter>form</filter>
+      <filter>anonymous</filter>
+    </filters>
+    <filters name="webLogin" class="org.geoserver.security.ConstantFilterChain" path="/j_spring_security_check,/j_spring_security_check/" disabled="false" allowSessionCreation="true" ssl="false" matchHTTPMethod="false">
+      <filter>form</filter>
+    </filters>
+    <filters name="webLogout" class="org.geoserver.security.LogoutFilterChain" path="/j_spring_security_logout,/j_spring_security_logout/" disabled="false" allowSessionCreation="false" ssl="false" matchHTTPMethod="false">
+      <filter>formLogout</filter>
+    </filters>
+    <filters name="rest" class="org.geoserver.security.ServiceLoginFilterChain" interceptorName="restInterceptor" exceptionTranslationName="exception" path="/rest/**" disabled="false" allowSessionCreation="false" ssl="false" matchHTTPMethod="false">
+      <filter>basic</filter>
+      <filter>anonymous</filter>
+    </filters>
+    <filters name="gwc" class="org.geoserver.security.ServiceLoginFilterChain" interceptorName="restInterceptor" exceptionTranslationName="exception" path="/gwc/rest/**" disabled="false" allowSessionCreation="false" ssl="false" matchHTTPMethod="false">
+      <filter>basic</filter>
+    </filters>
+    <filters name="default" class="org.geoserver.security.ServiceLoginFilterChain" interceptorName="interceptor" exceptionTranslationName="exception" path="/**" disabled="false" allowSessionCreation="false" ssl="false" matchHTTPMethod="false">
+      <filter>basic</filter>
+      <filter>anonymous</filter>
+    </filters>
+  </filterChain>
+  <rememberMeService>
+    <className>org.geoserver.security.rememberme.GeoServerTokenBasedRememberMeServices</className>
+    <key>geoserver</key>
+  </rememberMeService>
+</security>

--- a/geoserver/data_dir/security/filter/anonymous/config.xml
+++ b/geoserver/data_dir/security/filter/anonymous/config.xml
@@ -1,0 +1,5 @@
+<anonymousAuthentication>
+  <id>52857278:13c7ffd66a8:-7ff7</id>
+  <name>anonymous</name>
+  <className>org.geoserver.security.filter.GeoServerAnonymousAuthenticationFilter</className>
+</anonymousAuthentication>

--- a/geoserver/data_dir/security/filter/basic/config.xml
+++ b/geoserver/data_dir/security/filter/basic/config.xml
@@ -1,0 +1,6 @@
+<basicAuthentication>
+  <id>52857278:13c7ffd66a8:-7ffb</id>
+  <name>basic</name>
+  <className>org.geoserver.security.filter.GeoServerBasicAuthenticationFilter</className>
+  <useRememberMe>true</useRememberMe>
+</basicAuthentication>

--- a/geoserver/data_dir/security/filter/contextAsc/config.xml
+++ b/geoserver/data_dir/security/filter/contextAsc/config.xml
@@ -1,0 +1,6 @@
+<contextPersistence>
+  <id>52857278:13c7ffd66a8:-7ff9</id>
+  <name>contextAsc</name>
+  <className>org.geoserver.security.filter.GeoServerSecurityContextPersistenceFilter</className>
+  <allowSessionCreation>true</allowSessionCreation>
+</contextPersistence>

--- a/geoserver/data_dir/security/filter/contextNoAsc/config.xml
+++ b/geoserver/data_dir/security/filter/contextNoAsc/config.xml
@@ -1,0 +1,6 @@
+<contextPersistence>
+  <id>52857278:13c7ffd66a8:-7ff8</id>
+  <name>contextNoAsc</name>
+  <className>org.geoserver.security.filter.GeoServerSecurityContextPersistenceFilter</className>
+  <allowSessionCreation>false</allowSessionCreation>
+</contextPersistence>

--- a/geoserver/data_dir/security/filter/exception/config.xml
+++ b/geoserver/data_dir/security/filter/exception/config.xml
@@ -1,0 +1,5 @@
+<exceptionTranslation>
+  <id>52857278:13c7ffd66a8:-7ff2</id>
+  <name>exception</name>
+  <className>org.geoserver.security.filter.GeoServerExceptionTranslationFilter</className>
+</exceptionTranslation>

--- a/geoserver/data_dir/security/filter/form/config.xml
+++ b/geoserver/data_dir/security/filter/form/config.xml
@@ -1,0 +1,7 @@
+<usernamePasswordFilter>
+  <id>52857278:13c7ffd66a8:-7ffa</id>
+  <name>form</name>
+  <className>org.geoserver.security.filter.GeoServerUserNamePasswordAuthenticationFilter</className>
+  <passwordParameterName>password</passwordParameterName>
+  <usernameParameterName>username</usernameParameterName>
+</usernamePasswordFilter>

--- a/geoserver/data_dir/security/filter/formLogout/config.xml
+++ b/geoserver/data_dir/security/filter/formLogout/config.xml
@@ -1,0 +1,6 @@
+<logoutFilter>
+  <id>52857278:13c7ffd66a8:-7ff3</id>
+  <name>formLogout</name>
+  <className>org.geoserver.security.filter.GeoServerLogoutFilter</className>
+  <redirectURL>/web/</redirectURL>
+</logoutFilter>

--- a/geoserver/data_dir/security/filter/interceptor/config.xml
+++ b/geoserver/data_dir/security/filter/interceptor/config.xml
@@ -1,0 +1,7 @@
+<securityInterceptor>
+  <id>52857278:13c7ffd66a8:-7ff5</id>
+  <name>interceptor</name>
+  <className>org.geoserver.security.filter.GeoServerSecurityInterceptorFilter</className>
+  <allowIfAllAbstainDecisions>false</allowIfAllAbstainDecisions>
+  <securityMetadataSource>geoserverMetadataSource</securityMetadataSource>
+</securityInterceptor>

--- a/geoserver/data_dir/security/filter/rememberme/config.xml
+++ b/geoserver/data_dir/security/filter/rememberme/config.xml
@@ -1,0 +1,5 @@
+<rememberMeAuthentication>
+  <id>52857278:13c7ffd66a8:-7ff6</id>
+  <name>rememberme</name>
+  <className>org.geoserver.security.filter.GeoServerRememberMeAuthenticationFilter</className>
+</rememberMeAuthentication>

--- a/geoserver/data_dir/security/filter/restInterceptor/config.xml
+++ b/geoserver/data_dir/security/filter/restInterceptor/config.xml
@@ -1,0 +1,7 @@
+<securityInterceptor>
+  <id>52857278:13c7ffd66a8:-7ff4</id>
+  <name>restInterceptor</name>
+  <className>org.geoserver.security.filter.GeoServerSecurityInterceptorFilter</className>
+  <allowIfAllAbstainDecisions>false</allowIfAllAbstainDecisions>
+  <securityMetadataSource>restFilterDefinitionMap</securityMetadataSource>
+</securityInterceptor>

--- a/geoserver/data_dir/security/filter/roleFilter/config.xml
+++ b/geoserver/data_dir/security/filter/roleFilter/config.xml
@@ -1,0 +1,7 @@
+<roleFilter>
+  <id>52857278:13c7ffd66a8:-7fef</id>
+  <name>roleFilter</name>
+  <className>org.geoserver.security.filter.GeoServerRoleFilter</className>
+  <httpResponseHeaderAttrForIncludedRoles>roles</httpResponseHeaderAttrForIncludedRoles>
+  <roleConverterName>roleConverter</roleConverterName>
+</roleFilter>

--- a/geoserver/data_dir/security/filter/sslFilter/config.xml
+++ b/geoserver/data_dir/security/filter/sslFilter/config.xml
@@ -1,0 +1,6 @@
+<sslFilter>
+  <id>52857278:13c7ffd66a8:-7fee</id>
+  <name>sslFilter</name>
+  <className>org.geoserver.security.filter.GeoServerSSLFilter</className>
+  <sslPort>443</sslPort>
+</sslFilter>

--- a/geoserver/data_dir/security/layers.properties
+++ b/geoserver/data_dir/security/layers.properties
@@ -1,0 +1,9 @@
+# rule structure is namespace.layer.operation=role1,role2,...
+# namespace: a namespace or * to catch them all (in that case, layer should be *)
+# layer: a layer/featureType/coverage name or * to catch them all
+# operatin: r or w (read or write)
+# role list: * to imply all roles, or a list of explicit roles
+# The operation will be allowed if the current user has at least one of the
+# roles in the rule
+*.*.r=*
+*.*.w=*

--- a/geoserver/data_dir/security/masterpw.xml
+++ b/geoserver/data_dir/security/masterpw.xml
@@ -1,0 +1,3 @@
+<masterPassword>
+  <providerName>default</providerName>
+</masterPassword>

--- a/geoserver/data_dir/security/masterpw/default/config.xml
+++ b/geoserver/data_dir/security/masterpw/default/config.xml
@@ -1,0 +1,8 @@
+<urlProvider>
+  <id>52857278:13c7ffd66a8:-8000</id>
+  <name>default</name>
+  <className>org.geoserver.security.password.URLMasterPasswordProvider</className>
+  <readOnly>false</readOnly>
+  <url>file:passwd</url>
+  <encrypting>true</encrypting>
+</urlProvider>

--- a/geoserver/data_dir/security/masterpw/default/passwd
+++ b/geoserver/data_dir/security/masterpw/default/passwd
@@ -1,0 +1,1 @@
+3Gu9U3xKK1DdKLlI3KiqxXsFcetfUA54

--- a/geoserver/data_dir/security/pwpolicy/default/config.xml
+++ b/geoserver/data_dir/security/pwpolicy/default/config.xml
@@ -1,0 +1,10 @@
+<passwordPolicy>
+  <id>52857278:13c7ffd66a8:-7fff</id>
+  <name>default</name>
+  <className>org.geoserver.security.validation.PasswordValidatorImpl</className>
+  <uppercaseRequired>false</uppercaseRequired>
+  <lowercaseRequired>false</lowercaseRequired>
+  <digitRequired>false</digitRequired>
+  <minLength>0</minLength>
+  <maxLength>-1</maxLength>
+</passwordPolicy>

--- a/geoserver/data_dir/security/pwpolicy/master/config.xml
+++ b/geoserver/data_dir/security/pwpolicy/master/config.xml
@@ -1,0 +1,10 @@
+<passwordPolicy>
+  <id>52857278:13c7ffd66a8:-7ffe</id>
+  <name>master</name>
+  <className>org.geoserver.security.validation.PasswordValidatorImpl</className>
+  <uppercaseRequired>false</uppercaseRequired>
+  <lowercaseRequired>false</lowercaseRequired>
+  <digitRequired>false</digitRequired>
+  <minLength>8</minLength>
+  <maxLength>-1</maxLength>
+</passwordPolicy>

--- a/geoserver/data_dir/security/rest.properties
+++ b/geoserver/data_dir/security/rest.properties
@@ -1,0 +1,18 @@
+# Default REST security configuration.
+# 
+# By default this configuration locks down every rest call. The following is an example of a more
+# lax configuration in which read only (GET) access is allowed anonymously:
+# 
+#/**;GET=IS_AUTHENTICATED_ANONYMOUSLY
+#/**;POST,DELETE,PUT=ADMIN
+#
+# The following is an example of a configuration that could be used with the restconfig plugin in 
+# which only configuration in a specific workspace is restricted:
+#
+#/rest/workspaces/topp*;GET=ADMIN
+#/rest/workspaces/topp/**;GET=ADMIN
+#/**;POST,DELETE,PUT=ADMIN
+#
+#
+/**;GET=ADMIN
+/**;POST,DELETE,PUT=ADMIN

--- a/geoserver/data_dir/security/role/default/config.xml
+++ b/geoserver/data_dir/security/role/default/config.xml
@@ -1,0 +1,10 @@
+<roleService>
+  <id>52857278:13c7ffd66a8:-7ffc</id>
+  <name>default</name>
+  <className>org.geoserver.security.xml.XMLRoleService</className>
+  <fileName>roles.xml</fileName>
+  <checkInterval>10000</checkInterval>
+  <validating>true</validating>
+  <adminRoleName>ADMIN</adminRoleName>
+  <groupAdminRoleName>GROUP_ADMIN</groupAdminRoleName>
+</roleService>

--- a/geoserver/data_dir/security/role/default/roles.xml
+++ b/geoserver/data_dir/security/role/default/roles.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roleRegistry version="1.0" xmlns="http://www.geoserver.org/security/roles">
+    <roleList>
+        <role id="ADMIN"/>
+        <role id="GROUP_ADMIN"/>
+    </roleList>
+    <userList>
+        <userRoles username="admin">
+            <roleRef roleID="ADMIN"/>
+        </userRoles>
+    </userList>
+    <groupList/>
+</roleRegistry>

--- a/geoserver/data_dir/security/role/default/roles.xsd
+++ b/geoserver/data_dir/security/role/default/roles.xsd
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.geoserver.org/security/roles" xmlns:gsr="http://www.geoserver.org/security/roles" elementFormDefault="qualified">
+
+
+    <element name="roleRegistry" type="gsr:RoleRegistryType">
+        <key name="RoleKey">
+    		<selector xpath="gsr:roleList/gsr:role"/>
+    		<field xpath="@id"/>
+    	</key>
+    	<keyref name="ParentKey" refer="gsr:RoleKey">
+    		<selector xpath="gsr:roleList/gsr:role"/>
+    		<field xpath="@parentID"/>
+    	</keyref>
+    	<keyref name="UserRoleKey" refer="gsr:RoleKey">
+    		<selector xpath="gsr:userList/gsr:userRoles/gsr:roleRef"/>
+    		<field xpath="@roleID"/>
+    	</keyref>        	    
+    	<keyref name="GroupRoleKey" refer="gsr:RoleKey">
+    		<selector xpath="gsr:groupList/gsr:groupRoles/gsr:roleRef"/>
+    		<field xpath="@roleID"/>
+    	</keyref>        	        	        	    
+    </element>
+    
+    <complexType name="RoleType">
+       	<sequence>
+    		<element name="property" type="gsr:RolePropertyType" minOccurs="0" maxOccurs="unbounded"/> 
+    	</sequence>    	    
+    	<attribute name="id" type="string" use="required"></attribute>
+    	<attribute name="parentID" type="string" use="optional"></attribute>
+    </complexType>
+    
+    <complexType name="RoleRefType">
+    	<attribute name="roleID" type="string" use="required"></attribute>
+    </complexType>
+    
+    
+
+    <complexType name="RoleRegistryType">
+    	<sequence>
+    		<element name="roleList" type="gsr:RoleListType" minOccurs="1" maxOccurs="1"></element>
+    		<element name="userList" type="gsr:UserRolesType" minOccurs="1" maxOccurs="1"></element>
+    		<element name="groupList" type="gsr:GroupRolesType" minOccurs="1" maxOccurs="1"></element>
+    	</sequence>
+    	<attribute name="version" type="gsr:VersionType" use="required" ></attribute>    	
+    </complexType>
+
+    <complexType name="RoleListType">
+    	<sequence>
+    		<element name="role" type="gsr:RoleType" minOccurs="0" maxOccurs="unbounded"></element>
+    	</sequence>
+    </complexType>
+    
+    <complexType name="UserRoleRefListType">
+    	<sequence>
+    		<element name="roleRef" type="gsr:RoleRefType" minOccurs="0"
+    			maxOccurs="unbounded">
+    		</element>
+    	</sequence>
+    	<attribute name="username" type="string" use="required"></attribute>
+    </complexType>
+    
+    <complexType name="GroupRoleRefListType">
+    	<sequence>
+    		<element name="roleRef" type="gsr:RoleRefType" minOccurs="0"
+    			maxOccurs="unbounded">
+    		</element>
+    	</sequence>
+    	<attribute name="groupname" type="string" use="required"></attribute>
+    </complexType>
+    
+    <complexType name="GroupRolesType">
+    	<sequence>
+    		<element name="groupRoles" type="gsr:GroupRoleRefListType" minOccurs="0"
+    			maxOccurs="unbounded">
+    		</element>
+    	</sequence>
+    </complexType>
+    
+    <complexType name="UserRolesType">
+    	<sequence>
+    		<element name="userRoles" type="gsr:UserRoleRefListType" minOccurs="0"
+    			maxOccurs="unbounded">
+    		</element>
+    	</sequence>
+    </complexType>
+    
+    <complexType name="RolePropertyType">
+    	<simpleContent>
+    		<extension base="string">
+    			<attribute name="name" type="string" use="required"></attribute>
+    		</extension>
+    	</simpleContent>
+    </complexType>
+
+    <simpleType name="VersionType" >
+    	<restriction base="string">
+    		<enumeration value="1.0"></enumeration>
+    	</restriction>
+    </simpleType>
+    
+            
+</schema>

--- a/geoserver/data_dir/security/services.properties
+++ b/geoserver/data_dir/security/services.properties
@@ -3,5 +3,6 @@
 # A user can access a service only if he has one of the specified roles
 # If not specified in this file, a service or method will be considered unsecured
 
-# the following restricts all transactional opertations to the adminstator
-wfs.Transaction=ROLE_ADMINISTRATOR
+# Uncomment the following config if you want to test securing WFS service
+#wfs.GetFeature=ROLE_WFS_READ
+#wfs.Transaction=ROLE_WFS_WRITE

--- a/geoserver/data_dir/security/usergroup/default/config.xml
+++ b/geoserver/data_dir/security/usergroup/default/config.xml
@@ -1,0 +1,10 @@
+<userGroupService>
+  <id>52857278:13c7ffd66a8:-7ffd</id>
+  <name>default</name>
+  <className>org.geoserver.security.xml.XMLUserGroupService</className>
+  <fileName>users.xml</fileName>
+  <checkInterval>10000</checkInterval>
+  <validating>true</validating>
+  <passwordEncoderName>digestPasswordEncoder</passwordEncoderName>
+  <passwordPolicyName>default</passwordPolicyName>
+</userGroupService>

--- a/geoserver/data_dir/security/usergroup/default/users.xml
+++ b/geoserver/data_dir/security/usergroup/default/users.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<userRegistry version="1.0" xmlns="http://www.geoserver.org/security/users">
+    <users>
+        <user enabled="true" name="admin" password="digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw"/>
+    </users>
+    <groups/>
+</userRegistry>

--- a/geoserver/data_dir/security/usergroup/default/users.xsd
+++ b/geoserver/data_dir/security/usergroup/default/users.xsd
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.geoserver.org/security/users" xmlns:gsu="http://www.geoserver.org/security/users" elementFormDefault="qualified">
+
+
+    <element name="userRegistry" type="gsu:UserRegistryType">
+        <key name="UserKey">
+    		<selector xpath="gsu:users/gsu:user"/>
+    		<field xpath="@name"/>
+    	</key>
+    	<key name="GroupKey">
+        	<selector xpath="gsu:groups/gsu:group"/>
+        	<field xpath="@name"/>
+		</key>
+		<keyref name="ForeinUserKey" refer="gsu:UserKey">  
+  			<selector xpath="gsu:groups/gsu:group/gsu:member"/>
+  			<field xpath="@username"/>
+		</keyref>    				    		    		    	    		    
+    </element>
+    
+    <complexType name="UserType">
+       	<sequence>
+    		<element name="property" type="gsu:UserPropertyType" minOccurs="0" maxOccurs="unbounded"/> 
+    	</sequence>    	
+    
+    	<attribute name="name" type="string" use="required"></attribute>
+    	<attribute name="password" type="string" use="optional"></attribute>
+    	<attribute name="enabled" type="boolean" use="optional" default="true"></attribute>
+    </complexType>
+    
+    <complexType name="GroupType">
+    	<sequence>    		
+    		<!--<element name="member" type="gsu:UserRefType" minOccurs="0" maxOccurs="unbounded"></element> -->
+    		<element name="member" type="gsu:UserRefType" minOccurs="0" maxOccurs="unbounded">
+    		</element>
+    	</sequence>    
+    	<attribute name="name" type="string" use="required"></attribute>
+    	<attribute name="enabled" type="boolean" use="optional" default="true"></attribute>
+    </complexType>
+    
+    
+    <complexType name="UserRefType">
+    	<attribute name="username" type="string" use="required"></attribute>
+    </complexType>
+    
+    
+
+    <complexType name="UserRegistryType">
+    	<sequence>    		
+    		<element name="users" type="gsu:UsersType" minOccurs="1" maxOccurs="1" />
+    		<element name="groups" type="gsu:GroupsType" minOccurs="1" maxOccurs="1"/>
+    	</sequence>
+    	<attribute  name="version" type="gsu:VersionType" use="required" ></attribute>
+    </complexType>
+    
+    <complexType name="UsersType">
+    	<sequence>
+    		<element name="user" type="gsu:UserType" minOccurs="0"
+    			maxOccurs="unbounded">
+    		</element>
+    	</sequence>
+    </complexType>
+    
+    <complexType name="GroupsType">
+    	<sequence>
+    		<element name="group" type="gsu:GroupType" minOccurs="0"
+    			maxOccurs="unbounded">
+    		</element>
+    	</sequence>    	
+    </complexType>
+    
+                    
+    <complexType name="UserPropertyType">
+    	<simpleContent>
+    		<extension base="string">
+    			<attribute name="name" type="string" use="required"></attribute>
+    		</extension>
+    	</simpleContent>
+    </complexType>
+
+    <simpleType name="VersionType" >
+    	<restriction base="string">
+    		<enumeration value="1.0"></enumeration>
+    	</restriction>
+    </simpleType>
+</schema>

--- a/geoserver/data_dir/security/users.properties
+++ b/geoserver/data_dir/security/users.properties
@@ -1,3 +1,0 @@
-# administrator account
-admin=geoserver,ROLE_ADMINISTRATOR
-

--- a/geoserver/data_dir/styles/default_generic.sld
+++ b/geoserver/data_dir/styles/default_generic.sld
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.0.0" 
+                       xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd" 
+                       xmlns="http://www.opengis.net/sld" 
+                       xmlns:ogc="http://www.opengis.net/ogc" 
+                       xmlns:xlink="http://www.w3.org/1999/xlink" 
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NamedLayer>
+    <Name>generic</Name>
+    <UserStyle>
+      <Title>Generic</Title>
+      <Abstract>Generic style</Abstract>
+      <FeatureTypeStyle>
+        <Rule>
+          <Name>raster</Name>
+          <Title>raster</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="isCoverage"/>
+              <ogc:Literal>true</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <RasterSymbolizer>
+            <Opacity>1.0</Opacity>
+          </RasterSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Polygon</Name>
+          <Title>Polygon</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:Function name="geometry"/>
+              </ogc:Function>
+              <ogc:Literal>2</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill">#AAAAAA</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>Line</Name>
+          <Title>Line</Title>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:Function name="dimension">
+                <ogc:Function name="geometry"/>
+              </ogc:Function>
+              <ogc:Literal>1</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0000FF</CssParameter>
+              <CssParameter name="stroke-opacity">1</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+        <Rule>
+          <Name>point</Name>
+          <Title>Point</Title>
+          <ElseFilter/>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>square</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#FF0000</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>6</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+        <VendorOption name="ruleEvaluation">first</VendorOption>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/geoserver/data_dir/styles/generic.xml
+++ b/geoserver/data_dir/styles/generic.xml
@@ -1,0 +1,9 @@
+<style>
+  <id>StyleInfoImpl--306734ca:1565c71b416:-8000</id>
+  <name>generic</name>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.0.0</version>
+  </languageVersion>
+  <filename>default_generic.sld</filename>
+</style>

--- a/geoserver/data_dir/wms.xml
+++ b/geoserver/data_dir/wms.xml
@@ -27,15 +27,16 @@
   <verbose>false</verbose>
   <metadata>
     <entry key="svgAntiAlias">true</entry>
-    <entry key="GWC_WMS_Integration">true</entry>
     <entry key="svgRenderer">Batik</entry>
   </metadata>
-  <watermark class="org.geoserver.wms.WatermarkInfoImpl">
+  <watermark>
     <enabled>false</enabled>
     <position>BOT_RIGHT</position>
     <transparency>0</transparency>
   </watermark>
   <interpolation>Nearest</interpolation>
+  <getFeatureInfoMimeTypeCheckingEnabled>false</getFeatureInfoMimeTypeCheckingEnabled>
+  <getMapMimeTypeCheckingEnabled>false</getMapMimeTypeCheckingEnabled>
   <maxBuffer>25</maxBuffer>
   <maxRequestMemory>0</maxRequestMemory>
   <maxRenderingTime>0</maxRenderingTime>


### PR DESCRIPTION
@jodygarnett could you take a look at this?

A couple of notes: 
* After copying the releven parts (styles/countries, styles/usa, workspaces/countries, & workspaces/usa) to the boundlessgeo/suite-data project, there were no actual file changes, so it looks like we dont need to change that project?
* There was a rename of `users.properties => users.properties.old` as part of this commit. This seems like a deprecated file preserved elsewhere, but I could not find any file that looks like an appropriate modern replacement. Do we still need that file?