### PR TITLE
Fixed point stacker example

### DIFF
--- a/docs/usermanual/source/cartography/ysld/reference/transforms.rst
+++ b/docs/usermanual/source/cartography/ysld/reference/transforms.rst
@@ -120,7 +120,7 @@ The point stacker transform can be used to combine points that are close togethe
    - transform:
        name: vec:PointStacker
        params:
-       cellSize: 100
+         cellSize: 100
      rules:
      - symbolizers:
        - point:


### PR DESCRIPTION
Example required the cell size line to be indented for the transform to work