### PR TITLE
[DOCS] Active contact us links

### DIFF
--- a/docs/usermanual/source/install/redhat/packages.rst
+++ b/docs/usermanual/source/install/redhat/packages.rst
@@ -41,7 +41,7 @@ See the :ref:`install.redhat.packages.list` for details about the possible packa
 
    Make sure to replace each instance of ``<username>`` and ``<password>`` with the user name and password supplied to you.
 
-   .. note:: Please `contact us <http://boundlessgeo.com/about/contact-us/sales>`__ if you have purchased Boundless Suite and do not have a user name and password.
+   .. note:: Please `contact us <http://boundlessgeo.com/about/contact-us/>`__ if you have purchased Boundless Suite and do not have a user name and password.
 
 #. Search for Boundless packages to verify that the repository list is correct. 
 

--- a/docs/usermanual/source/install/ubuntu/packages.rst
+++ b/docs/usermanual/source/install/ubuntu/packages.rst
@@ -35,7 +35,7 @@ See the :ref:`install.ubuntu.packages.list` for details about the possible packa
 
    Make sure to replace each instance of ``<username>`` and ``<password>`` with the user name and password supplied to you.
 
-   .. note:: Please `contact us <http://boundlessgeo.com/about/contact-us/sales>`__ if you have purchased Boundless Suite and do not have a user name and password.
+   .. note:: Please `contact us <http://boundlessgeo.com/about/contact-us/>`__ if you have purchased Boundless Suite and do not have a user name and password.
 
 #. Update the repository list:
 


### PR DESCRIPTION
Contact us page URL changed on the Boundless website and had to be updated in the docs